### PR TITLE
Fixes #611 - remove pending texture handling from uv modifier. 

### DIFF
--- a/browser/plugins/three_uv_modifier.plugin.js
+++ b/browser/plugins/three_uv_modifier.plugin.js
@@ -6,7 +6,8 @@
 
 		this.input_slots = [{
 			name: 'texture',
-			dt: core.datatypes.TEXTURE
+			dt: core.datatypes.TEXTURE,
+			def: new THREE.Texture()
 		}, {
 			name: 'u offset',
 			dt: core.datatypes.FLOAT,
@@ -44,18 +45,13 @@
 	}
 
 	ThreeUVModifierPlugin.prototype.update_input = function(slot, data) {
-		if (slot.index === 0 && data) { // texture
-			if (data.image === THREE.Texture.DEFAULT_IMAGE) {
-				// store a reference - if the map is not there, the texture
-				// hasn't loaded - force the node to update until one is loaded
-				console.log('uv modifier - store pending texture', this)
-				this.pendingTexture = data
-				this.always_update = true
-			}
-			else {
-				console.log('uv modifier - store texture', this)
+		if (slot.index === 0) { // texture
+			if (data) {
 				this.texture = data.clone()
 				this.dirty = true
+			}
+			else {
+				this.texture = undefined
 			}
 		}
 		else if (slot.index === 1) { // u offset
@@ -83,18 +79,8 @@
 	}
 
 	ThreeUVModifierPlugin.prototype.update_state = function() {
-		console.log('uv modifier - update', this)
-		if (this.pendingTexture && this.pendingTexture.image !== THREE.Texture.DEFAULT_IMAGE) {
-			console.log('uv modifier - update state - create clone', this.pendingTexture.version)
-			this.texture = this.pendingTexture.clone()
-			//this.texture.version = this.pendingTexture.version + 1
-			this.always_update = false
-			this.pendingTexture = undefined
-			this.dirty = true
-		}
 
 		if (this.dirty && this.texture) {
-			console.log('uv modifier - set', this.texture.version)
 			this.texture.offset.set(this.uOffset, this.vOffset)
 			this.texture.repeat.set(this.uRepeat, this.vRepeat)
 			this.texture.needsUpdate = true
@@ -104,7 +90,6 @@
 	}
 
 	ThreeUVModifierPlugin.prototype.update_output = function() {
-		console.log('uv modifier - update output')
 		return this.texture
 	}
 

--- a/browser/plugins/url_texture_generator.plugin.js
+++ b/browser/plugins/url_texture_generator.plugin.js
@@ -86,7 +86,7 @@
 
 	UrlTexture.prototype.update_input = function(slot, data) {
 		if (this.state.url === data)
-			return;
+			return
 		this.state.url = data
 		this.state_changed()
 	}
@@ -96,10 +96,24 @@
 			return
 
 		this.texture = this.core.textureCache.get(this.state.url)
+		
+		// if the texture isn't ready, set a flag to indicate that we need to
+		// send an extra update after the texture has finished loaded
+		if (!this.texture.image || !this.texture.image.width === 0) {
+			this.waitingToLoad = true
+		}
+		
 		this.dirty = false
 	}
 
 	UrlTexture.prototype.update_output = function() {
+		if (this.waitingToLoad && this.texture && this.texture.image && this.texture.image.width !== 0) {
+			// force an extra update through the graph with a texture that has
+			// actual image data
+			this.waitingToLoad = false
+			this.updated = true
+		}
+
 		return this.texture
 	}
 

--- a/browser/plugins/url_texture_generator.plugin.js
+++ b/browser/plugins/url_texture_generator.plugin.js
@@ -85,10 +85,6 @@
 	}
 
 	UrlTexture.prototype.update_input = function(slot, data) {
-		if (this.state.url === data)
-			return
-		this.state.url = data
-		this.state_changed()
 	}
 
 	UrlTexture.prototype.update_state = function() {

--- a/browser/scripts/worldEditor/worldEditorOriginGrid.js
+++ b/browser/scripts/worldEditor/worldEditorOriginGrid.js
@@ -10,8 +10,8 @@ function WorldEditorOriginGrid() {
 			new THREE.LineBasicMaterial(
 				{ vertexColors: THREE.VertexColors, linewidth: 1, fog: false } )
 
-		this.color1 = new THREE.Color( 0xFFFFFF )
-		this.color2 = new THREE.Color( 0xBBBBBB )
+		this.color1 = new THREE.Color( 0xBBBBBB )
+		this.color2 = new THREE.Color( 0x888888 )
 
 		for ( var i = - size; i <= size; i += step ) {
 


### PR DESCRIPTION
Instead send an extra update from the texture loader plugin once the texture has finished loading, with the correct image data.

Also remove some logging I accidentally committed to develop in a previous commit.