### PR TITLE
Fixes #604 - fix 3d editor grid redraw 

### DIFF
--- a/browser/plugins/three_webgl_renderer.plugin.js
+++ b/browser/plugins/three_webgl_renderer.plugin.js
@@ -85,6 +85,8 @@
 		}
 
 		if (E2.app.worldEditor.isActive()) {
+			E2.app.worldEditor.preRenderUpdate()
+			
 			// Render the scene through the world editor camera
 			this.manager.render(this.scene, E2.app.worldEditor.getCamera())
 		}
@@ -95,10 +97,9 @@
 	}
 
 	ThreeWebGLRendererPlugin.prototype.patchSceneForWorldEditor = function() {
-		if (E2.app.worldEditor.isActive()) {
+		if (E2.app.worldEditor.updateScene) {
 			// tell the editor about changes in the scene
 			E2.app.worldEditor.updateScene(this.scene, this.perspectiveCamera)
-
 		}
 	}
 

--- a/browser/scripts/worldEditor/worldEditor.js
+++ b/browser/scripts/worldEditor/worldEditor.js
@@ -85,6 +85,14 @@ WorldEditor.prototype.update = function() {
 	}
 }
 
+WorldEditor.prototype.preRenderUpdate = function() {
+	// add the editor tree to the scene if it's not there already
+	var editorIdx = this.scene.children.indexOf(this.editorTree)
+	if (editorIdx < 0) {
+		this.scene.add(this.editorTree)
+	}
+}
+
 WorldEditor.prototype.getCamera = function() {
 	return this.camera.perspectiveCamera
 }
@@ -116,13 +124,6 @@ WorldEditor.prototype.updateScene = function(scene, camera) {
 	if (scene) {
 		scene.children[0].traverse( nodeHandler )
 	}
-
-	// add the editor tree to the scene if it's not there already
-	var editorIdx = this.scene.children.indexOf(this.editorTree)
-	if (editorIdx < 0) {
-		this.scene.add(this.editorTree)
-	}
-
 }
 
 WorldEditor.prototype.getEditorSceneTree = function() {


### PR DESCRIPTION
when switching between experience and editor view

the 3d scene needs to be patched to contain the editor helper objects. if the scene had only static objects, this patching was not happening unless forcing a scene update when in the editor.