### PR TITLE
ui refinements

### DIFF
--- a/browser/scripts/application.js
+++ b/browser/scripts/application.js
@@ -2044,9 +2044,6 @@ Application.prototype.start = function() {
 			bootbox.hideAll()
 	})
 
-	E2.dom.worldEditorButton.click(function() {
-		E2.app.toggleWorldEditor()
-	});
 
 	$('button#fullscreen').click(function() {
 		E2.app.toggleFullscreen()
@@ -2277,7 +2274,7 @@ E2.InitialiseEngi = function(vr_devices, loadGraphUrl) {
 	E2.dom.presetsClose = $('#presets-close');
 	
 	E2.dom.dbg = $('#dbg');
-	E2.dom.worldEditorButton = $('#worldEditor');
+
 	E2.dom.publishButton = $('#btn-publish');
 	E2.dom.play = $('#play');
 	E2.dom.play_i = $('i', E2.dom.play);

--- a/browser/scripts/ui-core.js
+++ b/browser/scripts/ui-core.js
@@ -96,10 +96,12 @@ VizorUI.prototype.setupStateStoreEventListeners = function() {
 	var $assets = dom.assetsLib, $presets = dom.presetsLib, $chat = dom.chatWindow;
 	var $patch_editor = dom.canvas_parent;
 
+
 	state
 		.on('changed:mode', function(mode) {
 			var inBuildMode = mode === uiMode.build
 			var inProgramMode = !inBuildMode
+
 			dom.btnBuildMode
 				.toggleClass('ui_on', inBuildMode)
 				.toggleClass('ui_off', inProgramMode);
@@ -107,38 +109,47 @@ VizorUI.prototype.setupStateStoreEventListeners = function() {
 				.toggleClass('ui_on', inProgramMode)
 				.toggleClass('ui_off', inBuildMode);
 
-			if (inProgramMode) {
-				dom.tabObjects.addClass('inactive ui_off');
-				dom.tabPresets.removeClass('inactive ui_off');
-			} else {
-				dom.tabObjects.removeClass('inactive ui_off');
-				dom.tabPresets.addClass('inactive ui_off');
-			}
+			// LIs
+			dom.tabObjects
+				.toggleClass('disabled', inProgramMode)
+				.toggleClass('ui_off', inProgramMode)
+				.toggleClass('ui_on', inBuildMode)
+
+			dom.tabPresets
+				.toggleClass('disabled', inBuildMode)
+				.toggleClass('ui_off', inBuildMode)
+				.toggleClass('ui_on', inProgramMode)
+
+			dom.btnMove.attr('disabled',!inBuildMode);
+			dom.btnScale.attr('disabled',!inBuildMode);
+			dom.btnRotate.attr('disabled',!inBuildMode);
+
+			setTimeout(function(){
+				if (inBuildMode) dom.tabObjects.find('a').trigger('click')
+				else if (inProgramMode) dom.tabPresets.find('a').trigger('click')
+			}, 100);
 		})
 		.emit('changed:mode', state.mode);
 
 	state
 		.on('changed:viewCamera', function(camera){
-			var worldEditorActive = camera === uiViewCam.world_editor;
+			var worldEditorActive = (camera === uiViewCam.world_editor);
 			dom.btnEditorCam.parent().toggleClass('active', worldEditorActive);
 			dom.btnVRCam.parent().toggleClass('active', !worldEditorActive);
 			E2.app.toggleWorldEditor(worldEditorActive);
-
-			dom.btnMove.attr('disabled',!worldEditorActive);
-			dom.btnScale.attr('disabled',!worldEditorActive);
-			dom.btnRotate.attr('disabled',!worldEditorActive);
-
 		})
 		.emit('changed:viewCamera', state.viewCamera);
 
 	state
 		.on('changed:visible', function(visible){
-			that.dom.btnHideAll.toggleClass('ui_off', visible);	// inverse
-		})
+
+		}) // stub, if a button exists
 		.emit('changed:visible', state.visible);
 
 	state
-		.on('changed:visibility:floating_panels', function(){}) // stub, if a button exists
+		.on('changed:visibility:floating_panels', function(visible){
+			that.dom.btnHideAll.toggleClass('ui_off', visible);	// inverse
+		})
 		.emit('changed:visibility:floating_panels', visibility.floating_panels);
 
 

--- a/browser/scripts/ui-core.js
+++ b/browser/scripts/ui-core.js
@@ -124,10 +124,9 @@ VizorUI.prototype.setupStateStoreEventListeners = function() {
 			dom.btnScale.attr('disabled',!inBuildMode);
 			dom.btnRotate.attr('disabled',!inBuildMode);
 
-			setTimeout(function(){
-				if (inBuildMode) dom.tabObjects.find('a').trigger('click')
-				else if (inProgramMode) dom.tabPresets.find('a').trigger('click')
-			}, 100);
+			if (inBuildMode) dom.tabObjects.find('a').trigger('click')
+			else if (inProgramMode) dom.tabPresets.find('a').trigger('click')
+
 		})
 		.emit('changed:mode', state.mode);
 
@@ -140,11 +139,7 @@ VizorUI.prototype.setupStateStoreEventListeners = function() {
 		})
 		.emit('changed:viewCamera', state.viewCamera);
 
-	state
-		.on('changed:visible', function(visible){
-
-		}) // stub, if a button exists
-		.emit('changed:visible', state.visible);
+	// nothing UI for top-level 'changed:visible' to process
 
 	state
 		.on('changed:visibility:floating_panels', function(visible){
@@ -430,15 +425,13 @@ VizorUI.prototype.onKeyDown = function(e) {
 		case (uiKeys.focusPresetSearchAlt):	// fallthrough
 		case (uiKeys.focusPresetSearch):
 			state.visibility.panel_presets = true;
-			setTimeout(function(){
-				if (that.isInProgramMode() || that.state.visibility.patch_editor) {
-					that.dom.tabPresets.find('a').trigger('click')
-					that.dom.presets_list.find('.searchbox input').focus().select();
-				} else {
-					that.dom.tabObjects.find('a').trigger('click')
-					that.dom.objectsList.find('.searchbox input').focus().select();
-				}
-			}, 100);
+			if (that.isInProgramMode()) {
+				that.dom.tabPresets.find('a').trigger('click')
+				that.dom.presets_list.find('.searchbox input').focus().select();
+			} else {
+				that.dom.tabObjects.find('a').trigger('click')
+				that.dom.objectsList.find('.searchbox input').focus().select();
+			}
 			e.preventDefault();
 			e.stopPropagation();
 			break;

--- a/browser/scripts/ui.js
+++ b/browser/scripts/ui.js
@@ -23,7 +23,12 @@ VizorUI.prototype.setupEventHandlers = function(e2, dom) {
 
 	var makeTabHandler = function(panelStateKey) {
 		return function(e) {
-			var $li = jQuery(e.currentTarget).parent();
+			if (e) {
+				e.preventDefault();
+			}
+			var $a = jQuery(e.currentTarget);
+			var $li = $a.parent();	// e.g. dom.tabObjects, dom.tabPresets, etc.
+			if ($li.hasClass('disabled')) return true;
 			var s = this.state.panelStates[panelStateKey];
 			var stateChanged = false;
 			if (s.collapsed) {
@@ -36,16 +41,13 @@ VizorUI.prototype.setupEventHandlers = function(e2, dom) {
 			}
 			if (stateChanged)
 				this.state.panelStates[panelStateKey] = s;
-			if (e) {
-				e.preventDefault();
-			}
 			return false;
 		}.bind(that);
 	};
 
-	jQuery('ul.nav-tabs a', dom.chatWindow).click(makeTabHandler('chat'));
-	jQuery('ul.nav-tabs a', dom.presetsLib).click(makeTabHandler('presets'));
-	jQuery('ul.nav-tabs a', dom.assetsLib).click(makeTabHandler('assets'));
+	dom.chatWindow.find('ul.nav-tabs a').click(makeTabHandler('chat'));
+	dom.presetsLib.find('ul.nav-tabs a').click(makeTabHandler('presets'));
+	if (dom.assetsLib) dom.assetsLib.find('ul.nav-tabs a').click(makeTabHandler('assets'));
 
 	var makeToggleHandler = function(panelStateKey) {
 		return function(e) {
@@ -263,7 +265,7 @@ VizorUI.prototype.onSearchResultsChange = function() {
 
 VizorUI.prototype.onBtnHideAllClicked = function(e) {
 	e.preventDefault();
-	this.toggleUILayer();
+	this.toggleFloatingPanels();
 	return false;
 }
 
@@ -304,15 +306,15 @@ VizorUI.prototype.toggleUILayer = function() {
 	this.state.visible = !this.state.visible;
 }
 
-VizorUI.prototype.enterEditorView = function() {
-	if ((this.state.viewCamera === uiViewCam.world_editor) && E2.app.worldEditor.isActive()) return false;
-	E2.app.toggleWorldEditor(true);
-	return false;
+VizorUI.prototype.enterEditorView = function(e) {
+	this.state.viewCamera = uiViewCam.world_editor
+	if (e) e.preventDefault()
+	return true;
 }
-VizorUI.prototype.enterVRView = function() {
-	if ((this.state.viewCamera === uiViewCam.vr) && !E2.app.worldEditor.isActive()) return false;
-	E2.app.toggleWorldEditor(false);
-	return false;
+VizorUI.prototype.enterVRView = function(e) {
+	this.state.viewCamera = uiViewCam.vr
+	if (e) e.preventDefault()
+	return true;
 }
 
 VizorUI.prototype.onChatResize = function() {
@@ -488,17 +490,10 @@ VizorUI.prototype.openPresetSaveDialog = function(serializedGraph) {
 
 VizorUI.prototype.setModeBuild = function() {
 	this.state.mode = uiMode.build
-	setTimeout(function(){
-		this.dom.tabObjects.find('a').trigger('click');
-	}.bind(this), 100);
-
 	return true;
 };
 VizorUI.prototype.setModeProgram = function() {
 	this.state.mode = uiMode.program
-	setTimeout(function(){
-		this.dom.tabPresets.find('a').trigger('click');
-	}.bind(this), 100);
 	return true;
 };
 

--- a/views/editor.handlebars
+++ b/views/editor.handlebars
@@ -91,19 +91,19 @@
 			<button class="toggle-button" id="presets-toggle" type="button">
 				<svg class="icon-arrow-vertical"><use xlink:href="#icon-arrow-vertical"></use></svg>
 			</button>
-			<ul class="nav nav-tabs" role="tablist">
-				<li class="active"><a href="#objects" role="tab" data-toggle="tab">Objects</a></li>
-				<li><a href="#presets" role="tab" data-toggle="tab">Patches</a></li>
-				{{!-- <li><a href="#graph" role="tab" data-toggle="tab">Tree</a></li> --}}
+			<ul class="nav nav-tabs">
+				<li><a href="#objects">Objects</a></li>
+				<li><a href="#presets">Patches</a></li>
+				{{!-- <li><a href="#graph">Tree</a></li> --}}
 			</ul>
 			<button class="close-button" id="presets-close" type="button">
 				<svg class="icon-assets-close"><use xlink:href="#icon-close"></use></svg>
 			</button>
 		</div>
 		<div class="tab-content">
-			<div role="tabpanel" class="tab-pane active" id="presets">
+			<div class="tab-pane active" id="presets">
 			</div>
-			<div role="tabpanel" class="tab-pane" id="objects">
+			<div class="tab-pane" id="objects">
 			</div>
 			{{!-- <div role="tabpanel" class="tab-pane" id="graph">
 				<div class="cell" id="structure"></div>
@@ -120,10 +120,10 @@
 		</button>
 		<ul class="nav nav-tabs" role="tablist">
 			<li class="active">
-				<a data-toggle="tab" role="tab" href="#chatTab" id="chatTabBtn">Chat</a>
+				<a href="#chatTab" id="chatTabBtn">Chat</a>
 			</li>
 			<li>
-				<a data-toggle="tab" role="tab" href="#peopleTab" id="peopleTabBtn">Users</a>
+				<a href="#peopleTab" id="peopleTabBtn">Users</a>
 			</li>
 		</ul>
 		<button class="close-button" id="chat-close" type="button">


### PR DESCRIPTION
- do not switch camera on build|program
- ui button hide all = hide floating panels
- tabs now controlled as per state rather than bootstrap (i.e. preset
tabs correctly disabled)
- return a realistic interpretation of “mode” (build|program) in
uistate
- fix erroneous click handling if assetsLib is null