### PR TITLE
Resolves #874 - add onDelete() callback for worldEditor

### DIFF
--- a/browser/scripts/application.js
+++ b/browser/scripts/application.js
@@ -952,6 +952,11 @@ Application.prototype.onDelete = function(e) {
 		return;
 
 	this.hoverNode = this.selectedNodes[0];
+
+	if (this.isWorldEditorActive()) {
+		this.worldEditor.onDelete(this.selectedNodes)
+	}
+
 	this.deleteSelectedNodes();
 }
 

--- a/browser/scripts/worldEditor/worldEditor.js
+++ b/browser/scripts/worldEditor/worldEditor.js
@@ -183,6 +183,10 @@ WorldEditor.prototype.setSelection = function(selected) {
 	}
 }
 
+WorldEditor.prototype.onDelete = function(nodes) {
+	this.transformControls.detach()
+}
+
 WorldEditor.prototype.onPaste = function(nodes) {
 	if (!nodes || nodes.length < 1) {
 		return


### PR DESCRIPTION
which detaches transform controls, so we don't end up with handles attached to nothing on delete