### PR TITLE
fix #875

### DIFF
--- a/browser/scripts/ui-core.js
+++ b/browser/scripts/ui-core.js
@@ -357,7 +357,6 @@ VizorUI.prototype.getModifiedKeyCode = function(keyCode) {	// adds modifier keys
 };
 VizorUI.prototype.trackModifierKeysForWorldEditor = function() {
 	if (!this.isInBuildMode()) return;
-	if (!this.state.selectedObjects.length) return;
 
 	if (!this.flags.key_shift_pressed && this.flags.key_ctrl_pressed) {
 		this.state.modifyMode = uiModifyMode.rotate


### PR DESCRIPTION
removed precaution check for selection before setting a new transform mode - this didn’t work after cmd+x or when selecting the camera helper anyway.