### PR TITLE
Resolves #900 - set camera state as updated on every frame

### DIFF
--- a/browser/plugins/three_vr_camera.plugin.js
+++ b/browser/plugins/three_vr_camera.plugin.js
@@ -46,6 +46,8 @@
 
 		this.rotationFromGraph = new THREE.Euler()
 		this.positionFromGraph = new THREE.Vector3()
+
+		this.perspectiveCameraRotationEuler = new THREE.Euler()
 	}
 
 	ThreeVRCameraPlugin.prototype = Object.create(Plugin.prototype)
@@ -114,6 +116,8 @@
 		this.perspectiveCamera.updateMatrixWorld()
 
 		this.controls.update(this.perspectiveCamera.position.clone(), this.perspectiveCamera.quaternion.clone())
+
+		this.updated = true
 	}
 
 	ThreeVRCameraPlugin.prototype.update_input = function(slot, data) {
@@ -159,8 +163,8 @@
 			return this.perspectiveCamera.position
 		}
 		else if (slot.index === 2) { // rotation
-			var euler = new THREE.Euler().setFromQuaternion(this.perspectiveCamera.quaternion)
-			return new THREE.Vector3(euler.x, euler.y, euler.z)
+			this.perspectiveCameraRotationEuler.setFromQuaternion(this.perspectiveCamera.quaternion)
+			return this.perspectiveCameraRotationEuler
 		}
 	}
 


### PR DESCRIPTION
as otherwise the graph would ignore it's outputs and not re-evaluate nodes depending on them

This wasn't affecting the camera output itself, as three renders the scene with the correct camera anyway but any nodes in between that depended on these output values were ignored (Node.update_recursive() on line 397 skips any nodes that don't have their .updated flag set)