### PR TITLE
fix header height

### DIFF
--- a/less/editor_shell.less
+++ b/less/editor_shell.less
@@ -48,8 +48,8 @@ body.bEditor {
 	>div {
 	  -webkit-flex: 1;
 	  flex: 1;
-	  height: 24px;
-	  line-height: 24px;
+	  height: (@row2-height - 2);
+	  line-height: (@row2-height - 2);
 	}
 
 
@@ -132,8 +132,8 @@ body.bEditor {
 	}
 	svg {
 	  margin-right: 10px;
-	  width: 23px;
-	  height: 16px;
+	  width: 22.8px;
+	  height: 15.5px;
 	  stroke: @editor-text-default;
 	}
 	&:hover {

--- a/less/variables.less
+++ b/less/variables.less
@@ -55,9 +55,9 @@
 
 // dimensions
 @menu-bar-height:       70px;
-@breadcrumb-height:     28px;
 @bottom-panel-height:   44px;
-@row2-height:			28px;
+@row2-height:			26px;
+@breadcrumb-height:     @row2-height;
 
 @height-editor-header:	@menu-bar-height + @row2-height;
 @height-editor-footer:	@bottom-panel-height;


### PR DESCRIPTION
header height was off by 2px resulting in extra blank space below switcher/name/breadcrumb row
see also #1015 

![screen shot 2016-01-08 at 15 41 40](https://cloud.githubusercontent.com/assets/14101296/12201840/55f34934-b61e-11e5-9e14-a8ae85b9a062.png)
