### PR TITLE
Fix an incorrect calculation of group plugin's pivot

### DIFF
--- a/browser/plugins/three_group.plugin.js
+++ b/browser/plugins/three_group.plugin.js
@@ -145,9 +145,9 @@
 				var obj = parent.children[i]
 
 				if (obj.backReference) {
-					center.x += obj.position.x
-					center.y += obj.position.y
-					center.z += obj.position.z
+					center.x += obj.backReference.state.position.x
+					center.y += obj.backReference.state.position.y
+					center.z += obj.backReference.state.position.z
 					++count
 				}
 			}
@@ -166,9 +166,9 @@
 		var m = new THREE.Matrix4().makeRotationFromQuaternion(quat).scale(scale)
 
 		var translation = center.clone().sub(this.lastCenter).applyMatrix4(m)
-		this.state.pivot.x += translation.x
-		this.state.pivot.y += translation.y
-		this.state.pivot.z += translation.z
+		this.pivot.x += translation.x
+		this.pivot.y += translation.y
+		this.pivot.z += translation.z
 
 		var gazeClickerCount = 0
 

--- a/browser/scripts/threeObject3dPlugin.js
+++ b/browser/scripts/threeObject3dPlugin.js
@@ -39,10 +39,10 @@ function ThreeObject3DPlugin(core) {
 
 		// names with underscores have to match with THREE.Quaternion
 		// member variable names because of to/from json serialisation
-		quaternion: {_x: 0, _y: 0, _z:0, _w:1},
-
-		pivot: {x: 0, y: 0, z:0}
+		quaternion: {_x: 0, _y: 0, _z:0, _w:1}
 	}
+
+	this.pivot = {x: 0, y: 0, z: 0}
 
 	this.lockTransformControls = false
 
@@ -126,9 +126,9 @@ ThreeObject3DPlugin.prototype.update_state = function() {
 		this.graphInputs.scale.z + this.state.scale.z)
 
 	this.object3d.position.set(
-		this.graphInputs.position.x + this.state.position.x + this.state.pivot.x,
-		this.graphInputs.position.y + this.state.position.y + this.state.pivot.y,
-		this.graphInputs.position.z + this.state.position.z + this.state.pivot.z)
+		this.graphInputs.position.x + this.state.position.x + this.pivot.x,
+		this.graphInputs.position.y + this.state.position.y + this.pivot.y,
+		this.graphInputs.position.z + this.state.position.z + this.pivot.z)
 
 	this.object3d.quaternion.set(
 		this.state.quaternion._x,


### PR DESCRIPTION
1) don't store pivot in plugin state as this shouldn't be saved to the graph (yet)

2) when calculating the averaged center of objects, only use state.position rather than object3d.position which would also include the pivot's contribution and cause accumulation