### PR TITLE
hide extra vr boilerplate buttons from player

### DIFF
--- a/browser/plugins/three_webgl_renderer.plugin.js
+++ b/browser/plugins/three_webgl_renderer.plugin.js
@@ -149,7 +149,7 @@
 			this.renderer.setPixelRatio(window.devicePixelRatio)
 
 			this.effect = new THREE.VREffect(this.renderer)
-			this.manager = new WebVRManager(this.renderer, this.effect, { hideButton: false })
+			this.manager = new WebVRManager(this.renderer, this.effect, { hideButton: true })
 
 			E2.core.webVRManager = this.manager		// allow e.g. the player/embed to access this
 


### PR DESCRIPTION
configures vr manager to not display its own buttons