### PR TITLE
Resolves #1107 - fix invalid gaze clicking outside the intended object

### DIFF
--- a/browser/plugins/three_gaze_clicker.plugin.js
+++ b/browser/plugins/three_gaze_clicker.plugin.js
@@ -219,7 +219,12 @@
 
 		if (intersects.length > 0) {
 			var obj = intersects[0].object
-			while (obj && !obj.gazeClickerCount) {
+
+			// traverse the hierarchy back
+			// we need to find an object with:
+			// - a positive gazeClickerCount (something is tracking its clickable state)
+			// - a reference back to a node (it is a object3d plugin's root object)
+			while (obj && !obj.gazeClickerCount && !(obj.backReference && obj.backReference.object3d === obj)) {
 				obj = obj.parent
 			}
 


### PR DESCRIPTION
this was bugging because the gaze clicker count was set to a positive integer on the whole hierarchy below a gaze clickable object - when gazing at anything, the code (which I've fixed to prevent this) found the scene node in the root which had a positive gaze clicker count -> everything appeared to be clickable