### PR TITLE
Resolves #1265 - prevent memory leak in webvr-manager

### DIFF
--- a/browser/vendor/three/webvr-manager.js
+++ b/browser/vendor/three/webvr-manager.js
@@ -296,6 +296,11 @@ function CardboardDistorter(renderer) {
 
     renderer.setSize = function (width, height) {
       genuineSetSize.call(renderer, width, height);
+
+      if (textureTarget && textureTarget.width == renderer.context.canvas.width && textureTarget.height == renderer.context.canvas.height) {
+        return
+      }
+
       textureTarget = createRenderTarget(renderer);
     };
   }


### PR DESCRIPTION
three.js r74 calls setSize() on every setPixelRatio() call, this causes the CardboardDistorter render target to be recreated on every frame even if it doesn't need to be recreated.

The better fix for this would be to not have to call setPixelRatio() on every frame but this will at least prevent the crash.