### PR TITLE
Resolves #1192 - Set editor camera to VR camera

### DIFF
--- a/browser/scripts/ui-core.js
+++ b/browser/scripts/ui-core.js
@@ -37,8 +37,10 @@ var uiKeys = {
 	toggleWorldEditorOrthographicCamera : 'O',
 	frameViewToSelection                : 'T',
 	toggleFullScreen 	                : 'F',
-	zeroVRCamera		                : '=',
+	moveVRCameraToEditorCamera          : '=',
+	moveEditorCameraToVRCamera          : 'shift+'+'V',
 	gotoParentGraph		                : ',',
+
 
 	moveSelectedNodesUp      : 38, // up arrow
 	moveSelectedNodesDown    : 40, // down arrow
@@ -586,9 +588,12 @@ VizorUI.prototype.onKeyPress = function(e) {
 			case uiKeys.frameViewToSelection:
 				E2.app.worldEditor.frameSelection();
 				break;
-			case uiKeys.zeroVRCamera:
-			case "shift+"+uiKeys.zeroVRCamera: // fi
-				E2.app.worldEditor.matchCamera();
+			case uiKeys.moveVRCameraToEditorCamera:
+			case "shift+"+uiKeys.moveVRCameraToEditorCamera: // fi
+				E2.app.worldEditor.matchVRToEditorCamera();
+				break;
+			case uiKeys.moveEditorCameraToVRCamera:
+				E2.app.worldEditor.matchEditorToVRCamera()
 				break;
 		}
 	}

--- a/browser/scripts/worldEditor/worldEditor.js
+++ b/browser/scripts/worldEditor/worldEditor.js
@@ -513,7 +513,7 @@ WorldEditor.prototype.getActiveSceneNode = function() {
 	return this.scene.backReference.parentNode
 }
 
-WorldEditor.prototype.matchCamera = function() {
+WorldEditor.prototype.matchVRToEditorCamera = function() {
 	// match the selected vr camera to world editor camera
 	var vrCameraPlugin = this.vrCamera.parent.backReference
 	var editCamera = this.getCamera()
@@ -526,6 +526,15 @@ WorldEditor.prototype.matchCamera = function() {
 	vrCameraPlugin.undoableSetState('quaternion', editCamera.quaternion.clone(), tempQuaternion)
 
 	E2.app.undoManager.end()
+}
+
+WorldEditor.prototype.matchEditorToVRCamera = function() {
+	// match the selected vr camera to world editor camera
+	var vrCameraPlugin = this.vrCamera.parent.backReference
+	var editCamera = this.getCamera()
+
+	editCamera.position.copy(vrCameraPlugin.state.position)
+	editCamera.quaternion.set(vrCameraPlugin.state.quaternion._x, vrCameraPlugin.state.quaternion._y, vrCameraPlugin.state.quaternion._z, vrCameraPlugin.state.quaternion._w)
 }
 
 WorldEditor.prototype.toggleGrid = function() {

--- a/views/patch_editor/help_shortcuts.handlebars
+++ b/views/patch_editor/help_shortcuts.handlebars
@@ -51,7 +51,10 @@
 				<dd>{{{modifyModeScale}}} / {{{modShift}}} + {{{modMeta}}}</dd>
 
 				<dt><abbr title="Sets the selected VR camera position to the current editor position">Zero VR camera</abbr></dt>
-				<dd>{{{zeroVRCamera}}}</dd>
+				<dd>{{{moveVRCameraToEditorCamera}}}</dd>
+
+                <dt><abbr title="Sets the world editor camera position to the current VR camera position">Zero Editor camera</abbr></dt>
+                <dd>{{{moveEditorCameraToVRCamera}}}</dd>
 
 				<dt><abbr title="Switch camera to orthographic mode, i.e. remove all perspective from the camera view.">Orthographic Camera</abbr></dt>
 				<dd>{{{toggleWorldEditorOrthographicCamera}}}</dd>


### PR DESCRIPTION
add a shortcut to moving the world editor camera to where the VR camera is