### PR TITLE
Resolves #1292 - Editing in vr cam

### DIFF
--- a/browser/plugins/three_vr_camera.plugin.js
+++ b/browser/plugins/three_vr_camera.plugin.js
@@ -59,6 +59,7 @@
 		this.domElement = E2.dom.webgl_canvas[0]
 
 		if (!this.dolly) {
+
 			this.dolly = new THREE.PerspectiveCamera()
 
 		}

--- a/browser/plugins/three_webgl_renderer.plugin.js
+++ b/browser/plugins/three_webgl_renderer.plugin.js
@@ -135,7 +135,7 @@
 	}
 
 	ThreeWebGLRendererPlugin.prototype.toggleFullScreen = function() {
-		var isFullscreen = !!(document.mozFullScreenElement || document.webkitFullscreenElement)
+		var isFullscreen = E2.util.isFullscreen()
 		console.log('ThreeWebGLRendererPlugin.toggleFullScreen', !isFullscreen)
 		this.manager.toggleFullScreen()
 	}

--- a/browser/scripts/application.js
+++ b/browser/scripts/application.js
@@ -1402,6 +1402,14 @@ Application.prototype.isWorldEditorActive = function() {
 }
 	
 Application.prototype.toggleFullscreen = function() {
+	var goingToFullscreen = !E2.util.isFullscreen()
+	if (goingToFullscreen) {
+		this.worldEditor.cameraSelector.selectCamera('vr')
+		if (this.worldEditor.isActive()) {
+			this.worldEditor.deactivate()
+		}
+	}
+
 	E2.core.emit('fullScreenChangeRequested')
 }
 

--- a/browser/scripts/application.js
+++ b/browser/scripts/application.js
@@ -1377,23 +1377,22 @@ Application.prototype.canInitiateCameraMove = function(e) {
 	return this.isVRCameraActive() && E2.util.isCanvasInFocus(e)
 }
 
-Application.prototype.toggleWorldEditor = function(forceState) {
-	var newActive = (typeof forceState !== 'undefined') ? forceState : !this.worldEditor.isActive()
-	if (newActive) {
-		this.worldEditor.activate()
-	}
-	else {
+Application.prototype.setViewCamera = function(cameraId) {
+	this.worldEditor.selectCamera(cameraId)
+
+	// if helper objects are off, and we're in vr camera, disable world editor entirely
+	if (!this.worldEditor.areEditorHelpersActive() && cameraId === 'vr') {
 		this.worldEditor.deactivate()
 	}
-	var isActive = this.worldEditor.isActive()
-
-	return isActive
+	else if (!this.worldEditor.isActive()) {
+		this.worldEditor.activate()
+	}
 }
 
 // is the VR (experience) camera active AND controllable?
 // i.e. graph is not visible
 Application.prototype.isVRCameraActive = function() {
-	return !(this.noodlesVisible || E2.app.worldEditor.isActive())
+	return !this.noodlesVisible && (!E2.app.worldEditor.isActive() || E2.app.worldEditor.cameraSelector.selectedCamera === 'vr')
 }
 
 // is the world editor visible AND controllable
@@ -1404,6 +1403,21 @@ Application.prototype.isWorldEditorActive = function() {
 	
 Application.prototype.toggleFullscreen = function() {
 	E2.core.emit('fullScreenChangeRequested')
+}
+
+Application.prototype.toggleHelperObjects = function() {
+	// toggle helper objects on & off
+	// additionally, if helper objects are off, and we're in vr camera, disable world editor entirely
+	var helpersActive = !this.worldEditor.areEditorHelpersActive()
+	this.worldEditor.setEditorHelpers(helpersActive)
+
+	if (this.worldEditor.isActive() && !helpersActive && this.worldEditor.cameraSelector.selectedCamera === 'vr') {
+		this.worldEditor.deactivate()
+	}
+	else if (!this.worldEditor.isActive() && helpersActive) {
+		// re-enable world editor if needed
+		this.worldEditor.activate()
+	}
 }
 
 Application.prototype.onFullScreenChanged = function() {

--- a/browser/scripts/ui-core-statestore.js
+++ b/browser/scripts/ui-core-statestore.js
@@ -77,7 +77,7 @@ var UiState = function(persistentStorageRef, context) {
 		mode 		: uiMode.build,
 		visible 	: true,				// overall visibility of the UI
 		context		: context || {},
-		viewCamera	: uiViewCam.world_editor,
+		viewCamera	: uiViewCam.birdsEye,
 		visibility	: {
 			_internal: {
 				breadcrumb: true,		// always true	(20151012)
@@ -159,7 +159,7 @@ var UiState = function(persistentStorageRef, context) {
 	var notifyBuildMode = function() {
 		if (that.visibility._internal.patch_editor)
 			that.mode = uiMode.program
-		else if (that.viewCamera !== uiViewCam.vr)
+		else //if (that.viewCamera !== uiViewCam.vr)
 			that.mode = uiMode.build
 	}
 	this.on('_internal:patch_editor', notifyBuildMode)

--- a/browser/scripts/ui-core-statestore.js
+++ b/browser/scripts/ui-core-statestore.js
@@ -159,7 +159,7 @@ var UiState = function(persistentStorageRef, context) {
 	var notifyBuildMode = function() {
 		if (that.visibility._internal.patch_editor)
 			that.mode = uiMode.program
-		else //if (that.viewCamera !== uiViewCam.vr)
+		else 
 			that.mode = uiMode.build
 	}
 	this.on('_internal:patch_editor', notifyBuildMode)

--- a/browser/scripts/ui-core.js
+++ b/browser/scripts/ui-core.js
@@ -551,9 +551,10 @@ VizorUI.prototype.onKeyPress = function(e) {
 		}
 
 	}
-	else if (E2.app.worldEditor.isActive && E2.app.worldEditor.cameraSelector.selectedCamera !== 'vr') {
-		// world editor (bird's eye camera only) -specific keys
-		switch(key) {
+	else if (E2.app.worldEditor.isActive) {
+		if (E2.app.worldEditor.cameraSelector.selectedCamera !== 'vr') {
+			// world editor (bird's eye camera only) -specific keys
+			switch(key) {
 			case uiKeys.toggleWorldEditorXCamera:
 				E2.app.worldEditor.setCameraView('-x');
 				break;
@@ -578,10 +579,10 @@ VizorUI.prototype.onKeyPress = function(e) {
 			case uiKeys.frameViewToSelection:
 				E2.app.worldEditor.frameSelection();
 				break;
+			}
 		}
-	}
-	else {// E2.app.worldEditor.isActive() && selected camera !== 'vr'
-		// world editor (vr and bird's eye camera) -specific keys
+
+		// world editor (any camera) -specific keys
 		switch(key) {
 			case uiKeys.modifyModeMove:
 				this.state.modifyMode = uiModifyMode.move;

--- a/browser/scripts/ui-core.js
+++ b/browser/scripts/ui-core.js
@@ -29,7 +29,7 @@ var uiKeys = {
 	focusChatPanel		: '@',
 	viewHelp 			: '?',
 
-	toggleWorldEditorHelpers            : 'H',
+	toggleEditorHelpers                 : 'H',
 	toggleWorldEditorGrid               : 'G',
 	toggleWorldEditorXCamera            : 'X',
 	toggleWorldEditorYCamera            : 'Y',
@@ -38,9 +38,7 @@ var uiKeys = {
 	frameViewToSelection                : 'T',
 	toggleFullScreen 	                : 'F',
 	moveVRCameraToEditorCamera          : '=',
-	moveEditorCameraToVRCamera          : 'shift+'+'V',
 	gotoParentGraph		                : ',',
-
 
 	moveSelectedNodesUp      : 38, // up arrow
 	moveSelectedNodesDown    : 40, // down arrow
@@ -75,8 +73,8 @@ var uiKeys = {
 };
 
 var uiViewCam = {
-	vr				: 'hmd',
-	world_editor	: 'editor'
+	vr			: 'hmd',
+	birdsEye	: 'birdsEye'
 };
 
 var uiEvent = { // emitted by ui (E2.ui) unless comments state otherwise
@@ -173,10 +171,10 @@ VizorUI.prototype.setupStateStoreEventListeners = function() {
 
 	state
 		.on('changed:viewCamera', function(camera){
-			var worldEditorActive = (camera === uiViewCam.world_editor);
-			dom.btnEditorCam.parent().toggleClass('active', worldEditorActive);
-			dom.btnVRCam.parent().toggleClass('active', !worldEditorActive);
-			E2.app.toggleWorldEditor(worldEditorActive);
+			var birdsEyeCameraActive = (camera === uiViewCam.birdsEye);
+			dom.btnEditorCam.parent().toggleClass('active', birdsEyeCameraActive);
+			dom.btnVRCam.parent().toggleClass('active', !birdsEyeCameraActive);
+			E2.app.setViewCamera(birdsEyeCameraActive ? 'perspective' : 'vr');
 		})
 		.emit('changed:viewCamera', state.viewCamera);
 
@@ -435,9 +433,12 @@ VizorUI.prototype.onKeyPress = function(e) {
 			e.preventDefault();
 			break;
 		case uiKeys.toggleEditorCamera:
-			state.viewCamera = (state.viewCamera === uiViewCam.vr) ? uiViewCam.world_editor : uiViewCam.vr;
+			state.viewCamera = (state.viewCamera === uiViewCam.vr) ? uiViewCam.birdsEye : uiViewCam.vr;
 			e.preventDefault();
 			e.stopPropagation();
+			break;
+		case uiKeys.toggleEditorHelpers:
+			E2.app.toggleHelperObjects()
 			break;
 		case uiKeys.focusPresetSearchAlt:
 		case uiKeys.focusPresetSearch:
@@ -550,8 +551,37 @@ VizorUI.prototype.onKeyPress = function(e) {
 		}
 
 	}
-	else {// E2.app.worldEditor.isActive()
-		// world editor-specific keys
+	else if (E2.app.worldEditor.isActive && E2.app.worldEditor.cameraSelector.selectedCamera !== 'vr') {
+		// world editor (bird's eye camera only) -specific keys
+		switch(key) {
+			case uiKeys.toggleWorldEditorXCamera:
+				E2.app.worldEditor.setCameraView('-x');
+				break;
+			case 'shift+' + uiKeys.toggleWorldEditorXCamera:
+				E2.app.worldEditor.setCameraView('+x');
+				break;
+			case uiKeys.toggleWorldEditorYCamera:
+				E2.app.worldEditor.setCameraView('-y');
+				break;
+			case 'shift+' + uiKeys.toggleWorldEditorYCamera:
+				E2.app.worldEditor.setCameraView('+y');
+				break;
+			case uiKeys.toggleWorldEditorZCamera:
+				E2.app.worldEditor.setCameraView('-z');
+				break;
+			case 'shift+' + uiKeys.toggleWorldEditorZCamera:
+				E2.app.worldEditor.setCameraView('+z');
+				break;
+			case uiKeys.toggleWorldEditorOrthographicCamera:
+				E2.app.worldEditor.toggleCameraOrthographic();
+				break;
+			case uiKeys.frameViewToSelection:
+				E2.app.worldEditor.frameSelection();
+				break;
+		}
+	}
+	else {// E2.app.worldEditor.isActive() && selected camera !== 'vr'
+		// world editor (vr and bird's eye camera) -specific keys
 		switch(key) {
 			case uiKeys.modifyModeMove:
 				this.state.modifyMode = uiModifyMode.move;
@@ -562,42 +592,12 @@ VizorUI.prototype.onKeyPress = function(e) {
 			case uiKeys.modifyModeScale:
 				this.state.modifyMode = uiModifyMode.scale;
 				break;
-			case uiKeys.toggleWorldEditorHelpers:
-				E2.app.worldEditor.toggleEditorHelpers();
-				break;
 			case uiKeys.toggleWorldEditorGrid:
 				E2.app.worldEditor.toggleGrid();
-				break;
-			case uiKeys.toggleWorldEditorXCamera:
-				E2.app.worldEditor.setCameraView('-x');
-				break;
-			case 'shift+'+uiKeys.toggleWorldEditorXCamera:
-				E2.app.worldEditor.setCameraView('+x');
-				break;
-			case uiKeys.toggleWorldEditorYCamera:
-				E2.app.worldEditor.setCameraView('-y');
-				break;
-			case 'shift+'+uiKeys.toggleWorldEditorYCamera:
-				E2.app.worldEditor.setCameraView('+y');
-				break;
-			case uiKeys.toggleWorldEditorZCamera:
-				E2.app.worldEditor.setCameraView('-z');
-				break;
-			case 'shift+'+uiKeys.toggleWorldEditorZCamera:
-				E2.app.worldEditor.setCameraView('+z');
-				break;
-			case uiKeys.toggleWorldEditorOrthographicCamera:
-				E2.app.worldEditor.toggleCameraOrthographic();
-				break;
-			case uiKeys.frameViewToSelection:
-				E2.app.worldEditor.frameSelection();
 				break;
 			case uiKeys.moveVRCameraToEditorCamera:
 			case "shift+"+uiKeys.moveVRCameraToEditorCamera: // fi
 				E2.app.worldEditor.matchVRToEditorCamera();
-				break;
-			case uiKeys.moveEditorCameraToVRCamera:
-				E2.app.worldEditor.matchEditorToVRCamera()
 				break;
 		}
 	}

--- a/browser/scripts/ui.js
+++ b/browser/scripts/ui.js
@@ -316,7 +316,7 @@ VizorUI.prototype.toggleUILayer = function() {
 }
 
 VizorUI.prototype.enterEditorView = function(e) {
-	this.state.viewCamera = uiViewCam.world_editor
+	this.state.viewCamera = uiViewCam.birdsEye
 	if (e) e.preventDefault()
 	return true;
 }

--- a/browser/scripts/worldEditor/worldEditor.js
+++ b/browser/scripts/worldEditor/worldEditor.js
@@ -7,7 +7,6 @@ function WorldEditor(domElement) {
 		active = true
 		this.cameraSelector.transformControls.enabled = true
 		this.cameraSelector.editorControls.enabled = true
-		this.showEditorHelpers = true
 	}
 
 	this.deactivate = function() {
@@ -82,7 +81,7 @@ WorldEditor.prototype.update = function() {
 		this.radialHelper.scale(gridScale)
 	}
 
-	this.cameraSelector.update(this.transformMode)
+	this.cameraSelector.update(this.transformMode, this.vrCamera)
 }
 
 WorldEditor.prototype.preRenderUpdate = function() {
@@ -123,7 +122,7 @@ WorldEditor.prototype.updateHelperHandles = function(scene, camera) {
 	}
 
 	// add handles for the camera helper
-	if (camera && camera.parent instanceof THREE.Camera) {
+	if (camera && camera.parent instanceof THREE.Camera && this.cameraSelector.selectedCamera !== 'vr') {
 		needsHandles.push(camera.parent)
 	}
 
@@ -528,6 +527,21 @@ WorldEditor.prototype.matchVRToEditorCamera = function() {
 	E2.app.undoManager.end()
 }
 
+WorldEditor.prototype.selectCamera = function(cameraId) {
+	var activePlugin = this.cameraSelector.transformControls.plugin
+	var selectedObject = activePlugin ? activePlugin.object3d : undefined
+	if (selectedObject !== undefined) {
+		this.cameraSelector.transformControls.detach()
+	}
+
+	this.cameraSelector.selectCamera(cameraId)
+
+	// reselect the selection for the new camera
+	if (selectedObject !== undefined) {
+		this.setSelection([selectedObject])
+	}
+}
+
 WorldEditor.prototype.matchEditorToVRCamera = function() {
 	// match the selected vr camera to world editor camera
 	var vrCameraPlugin = this.vrCamera.parent.backReference
@@ -553,23 +567,15 @@ WorldEditor.prototype.setCameraView = function(camera) {
 }
 
 WorldEditor.prototype.toggleCameraOrthographic = function() {
-	// save selected object
-	var activePlugin = this.cameraSelector.transformControls.plugin
-	var selectedObject = activePlugin ? activePlugin.object3d : undefined
-	if (selectedObject !== undefined) {
-		this.cameraSelector.transformControls.detach()
-	}
-
-	this.cameraSelector.selectCamera(this.cameraSelector.selectedCamera === 'orthographic' ? 'perspective' : 'orthographic')
-
-	// reselect the selection for the new camera
-	if (selectedObject !== undefined) {
-		this.setSelection([selectedObject])
-	}
+	this.selectCamera(this.cameraSelector.selectedCamera === 'orthographic' ? 'perspective' : 'orthographic')
 }
 
-WorldEditor.prototype.toggleEditorHelpers = function() {
-	this.showEditorHelpers = !this.showEditorHelpers
+WorldEditor.prototype.setEditorHelpers = function(set) {
+	this.showEditorHelpers = set
+}
+
+WorldEditor.prototype.areEditorHelpersActive = function() {
+	return this.showEditorHelpers
 }
 
 WorldEditor.prototype.frameSelection = function() {

--- a/browser/scripts/worldEditor/worldEditorCameraSelector.js
+++ b/browser/scripts/worldEditor/worldEditorCameraSelector.js
@@ -2,6 +2,8 @@ function WorldEditorCameraSelector(domElement) {
 
 	var perspectiveCamera = new WorldEditorCamera(domElement)
 	var orthographicCamera = new WorldEditorOrthographicCamera(domElement)
+	var vrCamera = new WorldEditorCamera(domElement)
+	vrCamera.camera.matrixAutoUpdate = false
 
 	this.axisCameras = {
 		'+x': {position: new THREE.Vector3(-1, 0, 0) },
@@ -10,6 +12,11 @@ function WorldEditorCameraSelector(domElement) {
 		'-x': {position: new THREE.Vector3( 1, 0, 0) },
 		'-y': {position: new THREE.Vector3( 0, 1, 0) },
 		'-z': {position: new THREE.Vector3( 0, 0, 1) }
+	}
+
+	var dummyEditorControls = {
+		center: new THREE.Vector3(),
+		enable: true
 	}
 
 	this.cameras = {
@@ -22,6 +29,11 @@ function WorldEditorCameraSelector(domElement) {
 			camera: orthographicCamera,
 			editorControls: new THREE.EditorControls(orthographicCamera.camera, domElement),
 			transformControls: new THREE.TransformControls(orthographicCamera.camera, domElement)
+		},
+		'vr' : {
+			camera: vrCamera,
+			editorControls: dummyEditorControls,
+			transformControls: new THREE.TransformControls(vrCamera.camera, domElement)
 		}
 	}
 
@@ -116,12 +128,18 @@ WorldEditorCameraSelector.prototype = {
 		}
 	},
 
-	update: function(transformMode) {
+	update: function(transformMode, vrCamera) {
 		// needs calling on every update otherwise the transform controls draw incorrectly
 		this.transformControls.setMode(transformMode)
 		this.transformControls.setSpace('local')
 		this.transformControls.updateTransformLock()
 
 		this.cameras[this.currentCameraId].camera.update();
+
+		if (vrCamera && this.currentCameraId === 'vr') {
+			// keep the editor vr camera in sync with the current vr camera plugin
+			vrCamera.updateMatrixWorld()
+			this.cameras.vr.camera.camera.matrixWorld.copy(vrCamera.matrixWorld)
+		}
 	}
 }

--- a/views/patch_editor/help_shortcuts.handlebars
+++ b/views/patch_editor/help_shortcuts.handlebars
@@ -53,9 +53,6 @@
 				<dt><abbr title="Sets the selected VR camera position to the current editor position">Zero VR camera</abbr></dt>
 				<dd>{{{moveVRCameraToEditorCamera}}}</dd>
 
-                <dt><abbr title="Sets the world editor camera position to the current VR camera position">Zero Editor camera</abbr></dt>
-                <dd>{{{moveEditorCameraToVRCamera}}}</dd>
-
 				<dt><abbr title="Switch camera to orthographic mode, i.e. remove all perspective from the camera view.">Orthographic Camera</abbr></dt>
 				<dd>{{{toggleWorldEditorOrthographicCamera}}}</dd>
 
@@ -63,7 +60,7 @@
 				<dd>{{{toggleWorldEditorGrid}}}</dd>
 
 				<dt><abbr title="Toggle all build helper objects on/off">Toggle Helpers</abbr></dt>
-				<dd>{{{toggleWorldEditorHelpers}}}</dd>
+				<dd>{{{toggleEditorHelpers}}}</dd>
 
 				<dt><abbr title="Align camera to primary axis. Holding shift will reverse camera direction.">Align Camera to Axis</abbr></dt>
 				<dd>{{{toggleWorldEditorXCamera}}} / {{{toggleWorldEditorYCamera}}} / {{{toggleWorldEditorZCamera}}}</dd>


### PR DESCRIPTION
The World Editor now has a VR camera mode, in which it looks through the currently active VR Camera.

The World Editor is now active at all times apart from when both of these conditions are true:
1) the VR camera is active
2) the helper objects are invisible
Then the editor is disabled which should remove some of the editor overhead and give us the exact same result as a published graph