### PR TITLE
Resolves #1306, resolves #1307 - edit in vr cam fixes

### DIFF
--- a/browser/scripts/application.js
+++ b/browser/scripts/application.js
@@ -1377,11 +1377,11 @@ Application.prototype.canInitiateCameraMove = function(e) {
 	return this.isVRCameraActive() && E2.util.isCanvasInFocus(e)
 }
 
-Application.prototype.setViewCamera = function(cameraId) {
-	this.worldEditor.selectCamera(cameraId)
+Application.prototype.setViewCamera = function(isBirdsEyeCamera) {
+	this.worldEditor.selectCamera(isBirdsEyeCamera ? 'birdsEye' : 'vr')
 
 	// if helper objects are off, and we're in vr camera, disable world editor entirely
-	if (!this.worldEditor.areEditorHelpersActive() && cameraId === 'vr') {
+	if (!this.worldEditor.areEditorHelpersActive() && !isBirdsEyeCamera) {
 		this.worldEditor.deactivate()
 	}
 	else if (!this.worldEditor.isActive()) {

--- a/browser/scripts/ui-core.js
+++ b/browser/scripts/ui-core.js
@@ -174,7 +174,7 @@ VizorUI.prototype.setupStateStoreEventListeners = function() {
 			var birdsEyeCameraActive = (camera === uiViewCam.birdsEye);
 			dom.btnEditorCam.parent().toggleClass('active', birdsEyeCameraActive);
 			dom.btnVRCam.parent().toggleClass('active', !birdsEyeCameraActive);
-			E2.app.setViewCamera(birdsEyeCameraActive ? 'perspective' : 'vr');
+			E2.app.setViewCamera(birdsEyeCameraActive);
 		})
 		.emit('changed:viewCamera', state.viewCamera);
 

--- a/browser/scripts/ui-core.js
+++ b/browser/scripts/ui-core.js
@@ -579,6 +579,10 @@ VizorUI.prototype.onKeyPress = function(e) {
 			case uiKeys.frameViewToSelection:
 				E2.app.worldEditor.frameSelection();
 				break;
+			case uiKeys.moveVRCameraToEditorCamera:
+			case "shift+"+uiKeys.moveVRCameraToEditorCamera: // fi
+				E2.app.worldEditor.matchVRToEditorCamera();
+				break;
 			}
 		}
 
@@ -595,10 +599,6 @@ VizorUI.prototype.onKeyPress = function(e) {
 				break;
 			case uiKeys.toggleWorldEditorGrid:
 				E2.app.worldEditor.toggleGrid();
-				break;
-			case uiKeys.moveVRCameraToEditorCamera:
-			case "shift+"+uiKeys.moveVRCameraToEditorCamera: // fi
-				E2.app.worldEditor.matchVRToEditorCamera();
 				break;
 		}
 	}

--- a/browser/scripts/worldEditor/worldEditor.js
+++ b/browser/scripts/worldEditor/worldEditor.js
@@ -527,19 +527,28 @@ WorldEditor.prototype.matchVRToEditorCamera = function() {
 	E2.app.undoManager.end()
 }
 
-WorldEditor.prototype.selectCamera = function(cameraId) {
+WorldEditor.prototype.callAndRetainSelection = function(callback) {
 	var activePlugin = this.cameraSelector.transformControls.plugin
 	var selectedObject = activePlugin ? activePlugin.object3d : undefined
 	if (selectedObject !== undefined) {
 		this.cameraSelector.transformControls.detach()
 	}
 
-	this.cameraSelector.selectCamera(cameraId)
+	if (callback) {
+		callback()
+	}
 
 	// reselect the selection for the new camera
 	if (selectedObject !== undefined) {
 		this.setSelection([selectedObject])
 	}
+}
+
+WorldEditor.prototype.selectCamera = function(cameraId) {
+	var that = this
+	this.callAndRetainSelection(function() {
+		that.cameraSelector.selectCamera(cameraId)
+	})
 }
 
 WorldEditor.prototype.matchEditorToVRCamera = function() {
@@ -567,7 +576,10 @@ WorldEditor.prototype.setCameraView = function(camera) {
 }
 
 WorldEditor.prototype.toggleCameraOrthographic = function() {
-	this.selectCamera(this.cameraSelector.selectedCamera === 'orthographic' ? 'perspective' : 'orthographic')
+	var that = this
+	this.callAndRetainSelection(function() {
+		that.cameraSelector.selectNextCameraInCurrentCategory()
+	})
 }
 
 WorldEditor.prototype.setEditorHelpers = function(set) {

--- a/browser/scripts/worldEditor/worldEditorCameraSelector.js
+++ b/browser/scripts/worldEditor/worldEditorCameraSelector.js
@@ -14,37 +14,47 @@ function WorldEditorCameraSelector(domElement) {
 		'-z': {position: new THREE.Vector3( 0, 0, 1) }
 	}
 
+	orthographicCamera.pos
+
 	var dummyEditorControls = {
 		center: new THREE.Vector3(),
 		enable: true
 	}
 
+	this.cameraCategories = {
+		'birdsEye': [
+			{
+				camera: perspectiveCamera,
+				editorControls: new THREE.EditorControls(perspectiveCamera.camera, domElement),
+				transformControls: new THREE.TransformControls(perspectiveCamera.camera, domElement),
+				canSwitchToPrimaryAxis: true
+			},
+			{
+				camera: orthographicCamera,
+				editorControls: new THREE.EditorControls(orthographicCamera.camera, domElement),
+				transformControls: new THREE.TransformControls(orthographicCamera.camera, domElement),
+				canSwitchToPrimaryAxis: true
+			}
+		],
+		'vr': [
+			{
+				camera: vrCamera,
+				editorControls: dummyEditorControls,
+				transformControls: new THREE.TransformControls(vrCamera.camera, domElement),
+				canSwitchToPrimaryAxis: false
+			}
+		]}
+
 	this.cameras = {
-		'perspective': {
-			camera: perspectiveCamera,
-			editorControls: new THREE.EditorControls(perspectiveCamera.camera, domElement),
-			transformControls: new THREE.TransformControls(perspectiveCamera.camera, domElement)
-		},
-		'orthographic': {
-			camera: orthographicCamera,
-			editorControls: new THREE.EditorControls(orthographicCamera.camera, domElement),
-			transformControls: new THREE.TransformControls(orthographicCamera.camera, domElement)
-		},
-		'vr' : {
-			camera: vrCamera,
-			editorControls: dummyEditorControls,
-			transformControls: new THREE.TransformControls(vrCamera.camera, domElement)
-		}
+		'birdsEye': this.cameraCategories.birdsEye[0],
+		'vr': this.cameraCategories.vr[0]
 	}
 
-	this.currentCameraId = 'perspective'
+	this.currentCameraId = 'birdsEye'
 
-	var that = this
-
-	Object.keys(this.cameras).forEach( function (key, i) {
-		var curCam = that.cameras[key]
-		curCam.editorControls.enabled = false
-		curCam.transformControls.enabled = false
+	function initialiseCamera(camera) {
+		camera.editorControls.enabled = false
+		camera.transformControls.enabled = false
 
 		function mouseDown() {
 			this.editorControls.enabled = false
@@ -58,10 +68,13 @@ function WorldEditorCameraSelector(domElement) {
 			this.editorControls.enabled = true
 		}
 
-		curCam.transformControls.addEventListener('mouseDown', mouseDown.bind(curCam))
+		camera.transformControls.addEventListener('mouseDown', mouseDown.bind(camera))
 
-		curCam.transformControls.addEventListener('mouseUp', mouseUp.bind(curCam))
-	})
+		camera.transformControls.addEventListener('mouseUp', mouseUp.bind(camera))
+	}
+
+	this.cameraCategories.birdsEye.map(initialiseCamera)
+	this.cameraCategories.vr.map(initialiseCamera)
 
 }
 
@@ -84,36 +97,76 @@ WorldEditorCameraSelector.prototype = {
 		return this.currentCameraId
 	},
 
+	saveCameraState: function(camera) {
+		return {
+			'position': camera.position.clone(),
+			'rotation': camera.rotation.clone(),
+			'quaternion': camera.quaternion.clone(),
+			'scale': camera.scale.clone(),
+
+			'transformControlsEnabled': this.transformControls.enabled,
+			'editorControlsEnabled': this.editorControls.enabled
+		}
+	},
+
+	applySavedState: function(state) {
+		this.transformControls.enabled = state.transformControlsEnabled
+		this.editorControls.enabled = state.editorControlsEnabled
+
+		this.camera.position.copy(state.position)
+		this.camera.rotation.copy(state.rotation)
+		this.camera.quaternion.copy(state.quaternion)
+		this.camera.scale.copy(state.scale)
+	},
+
 	selectCamera: function(id) {
 		if (id === this.currentCameraId) {
 			return
 		}
 
+		// save camera position, orientation etc
+		var oldCameraState = this.saveCameraState(this.camera)
+
 		// disable previous camera
-		var wasTransformControlEnabled = this.transformControls.enabled
-		var wasEditorControlEnabled = this.editorControls.enabled
-
-		var oldPosition = this.camera.position.clone()
-		var oldRotation = this.camera.rotation.clone()
-		var oldQuaternion = this.camera.quaternion.clone()
-		var oldScale = this.camera.scale.clone()
-
 		this.transformControls.enabled = false
 		this.editorControls.enabled = false
 
 		this.currentCameraId = id
 
-		// enable next camera
-		this.transformControls.enabled = wasTransformControlEnabled
-		this.editorControls.enabled = wasEditorControlEnabled
+		// apply saved state
+		this.applySavedState(oldCameraState)
+	},
 
-		this.camera.position.copy(oldPosition)
-		this.camera.rotation.copy(oldRotation)
-		this.camera.quaternion.copy(oldQuaternion)
-		this.camera.scale.copy(oldScale)
+	selectNextCameraInCurrentCategory: function() {
+		var curCam = this.cameras[this.currentCameraId]
+		var camCat = this.cameraCategories[this.currentCameraId]
+
+		for (var i = 0; i < camCat.length; ++i) {
+			if (curCam === camCat[i]) {
+				curCam = camCat[(i+1) % camCat.length]
+
+				break
+			}
+		}
+
+		// save camera position, orientation etc
+		var oldCameraState = this.saveCameraState(this.camera)
+
+		// disable previous camera
+		this.transformControls.enabled = false
+		this.editorControls.enabled = false
+
+		this.cameras[this.currentCameraId] = curCam
+
+		// apply saved state
+		this.applySavedState(oldCameraState)
 	},
 
 	setView: function(id) {
+		if (!this.cameras[this.currentCameraId].canSwitchToPrimaryAxis) {
+			return
+		}
+
 		var view = this.axisCameras[id].position.clone()
 
 		var target = this.transformControls.object


### PR DESCRIPTION
'=' only works in bird's eye view
remember orthographicness when switching back from VR camera

In the ortographicness fix, essentially we now split the cameras into two categories ('birds eye' and 'vr') in the camera selector and pressing 'O' switches the camera into another one within the same category.