### PR TITLE
360-disable auto fade-out

### DIFF
--- a/browser/scripts/threesixty.js
+++ b/browser/scripts/threesixty.js
@@ -85,6 +85,7 @@ var vizor360 = new function() {
 		var baseUrl = 'http://' + host
 		playerUI.data.shareURL = baseUrl + asset.path
 		playerUI.data.embedSrc = baseUrl + 'embed/' + asset.path
+		playerUI.headerEnableAutoFadeout()
 		history.pushState({}, '', asset.path)
 		E2.app.player.loadAndPlay(asset.url, true);
 	}
@@ -410,7 +411,7 @@ var vizor360 = new function() {
 
 	this.init = function() {
 		// scoped above
-		playerUI.headerDefaultFadeoutTimeMs = 4000
+		playerUI.headerDefaultFadeoutTimeMs = 3500
 
 		var $header = $('header')
 		var $container360 = $('#container360')
@@ -448,6 +449,7 @@ var vizor360 = new function() {
 		}, null)
 
 		playerUI.data.shareURL = null
+		playerUI.headerDisableAutoFadeout()
 	}
 }
 

--- a/views/graph/show.handlebars
+++ b/views/graph/show.handlebars
@@ -73,6 +73,9 @@ var have_webgl = (function () {   // http://www.browserleaks.com/webgl#howto-det
 var playerUI = new function() {
     var that = this
 
+    this.headerEnableQueueFadeout = true
+    this.headerDefaultFadeoutTimeMs = 2500
+
     this.eventNames = {
         controlsDisplayed : 'controlsDisplayed',
         controlsHidden :    'controlsHidden',
@@ -89,7 +92,7 @@ var playerUI = new function() {
     this.vrCameraEnabled = true
     this.data = {}
     var topUrl = 'http://' + window.location.hostname
-    this.data.shareURL = topUrl + '/{{graph.owner}}/{{graph.name}}',
+    this.data.shareURL = topUrl + '/{{graph.owner}}/{{graph.name}}'
     this.data.embedSrc = topUrl + '/embed/{{graph.owner}}/{{graph.name}}'
 
     this.selectStage = function(elementId) {
@@ -142,7 +145,6 @@ var playerUI = new function() {
 
 
     var fadeoutTimer = null
-    this.headerDefaultFadeoutTimeMs = 2500
 
 
     var clearFadeoutTimer = function () {
@@ -182,9 +184,20 @@ var playerUI = new function() {
         return true
     }
 
+    this.headerDisableAutoFadeout = function() {
+        clearFadeoutTimer()
+        this.headerEnableQueueFadeout = false
+        this.headerFadeIn()
+    }
 
-    this.queueHeaderFadeOut = function(timeoutMs) {
+    this.headerEnableAutoFadeout = function() {
+        this.headerEnableQueueFadeout = true
+    }
+
+
+    this.queueHeaderFadeOut = function(timeoutMs, forceIfAutoDisabled) {
         if (E2.app.player.current_state !== E2.app.player.state.PLAYING) return true
+        if (!that.headerEnableQueueFadeout && (!forceIfAutoDisabled)) return true
         if (!headerIsVisible) return
         if (inVR()) {
             $body.removeClass('withPlayerControls')
@@ -286,7 +299,7 @@ var playerUI = new function() {
                     headerFadeIn()
                     queueFadeoutTimer()
                 } else {
-                    queueFadeoutTimer(100)  // give any button some time to react
+                    queueFadeoutTimer(100, true)  // give any button some time to react
                 }
 
                 return true


### PR DESCRIPTION
disables the automatic fadeout of the header and centre heading if loading for the first time. on subsequent plays (e.g. when a file is uploaded) that is reenabled.