### PR TITLE
Resolves #1332 - no render until loaded

### DIFF
--- a/browser/scripts/player.js
+++ b/browser/scripts/player.js
@@ -173,6 +173,14 @@ Player.prototype.remove_parameter_listener = function(id, listener) {
 Player.prototype.loadAndPlay = function(url, forcePlay) {
 	var dfd = when.defer()
 
+	// if there's an existing anim frame request, cancel it
+	// so that nothing gets rendered until we ask to play() again after
+	// loading
+	if(this.interval !== null) {
+		cancelAnimFrame(this.interval)
+		this.interval = null
+	}
+
 	if (E2.core.audioContext) {
 		// iOS requires a user interaction to play sound
 		// so as this is called on touchstart,


### PR DESCRIPTION
the player didn't stop playback when loading the new graph so the renderer would keep rendering while loading, before assets had been loaded

an alternative to this change would be to call Player.stop() which also cancels the anim frame