### PR TITLE
resolve an issue where the player might not start correctly

### DIFF
--- a/browser/scripts/player.js
+++ b/browser/scripts/player.js
@@ -238,7 +238,9 @@ function CreatePlayer(vr_devices, cb) {
 		}
 	}
 
-	E2.app.canInitiateCameraMove = function() { return true }
+	E2.app.canInitiateCameraMove = function(e) {
+		return (e && e.target.tagName === 'CANVAS')  // #790
+	}
 
 	// Shared gl context for three
 	var gl_attributes = {


### PR DESCRIPTION
See #790 
This is a bug spread across a few areas. The webvr boilerplate polyfill tests for mousedown on the body to initiate a camera move, but at the time the renderer’s target is hidden (display:none) because we’re still showing a “loading” stage, and so its returned dimensions are 0x0.  However, the polyfill catches other things such as buttons that may be sitting on top of the render target. If a click is accompanied by a mouse move of just one pixel, this then breaks rendering, or more likely just the camera. A correct check would test whether a click before move has originated on the renderer’s dom element, but it seems the polyfill knows nothing about a renderer.