### PR TITLE
add deploy.sh into repo, add provisioning step to deployment, fix player push

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ ADD . /usr/src/app
 WORKDIR /usr/src/app
 
 RUN npm install --silent -g forever
-RUN npm install --unsafe-perm
+RUN npm install --silent --unsafe-perm
 
-RUN ./node_modules/.bin/gulp
+RUN ./node_modules/.bin/gulp golive
 
 RUN node ./tools/editorBundler.js
 

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,0 +1,56 @@
+alias d='sudo docker'
+
+# source environment variables from local file
+. ./env
+
+if [ -e $FQDN ];
+then
+     echo "No environment?"
+     exit 1
+fi
+
+echo ----------------------------------------
+echo          Deploying $FQDN
+echo ----------------------------------------
+
+# update from git
+git pull --rebase
+
+# build docker container
+d build -t $FQDN:v1 .
+
+echo ----------------------------------------
+echo          Destroying old $FQDN
+echo ----------------------------------------
+
+# destroy existing container
+d stop $FQDN
+d rm $FQDN
+
+echo ----------------------------------------
+echo          Provisioning $FQDN
+echo ----------------------------------------
+
+# run provisioning step
+d run --rm \
+	--link destroy-mongo:mongo \
+	$FQDN:v1 \
+	node ./node_modules/gulp/bin/gulp push
+
+echo ----------------------------------------
+echo          Running $FQDN
+echo ----------------------------------------
+
+# start container
+d run -d --name $FQDN \
+     -e "FQDN=$FQDN" \
+     -e "MANDRILL=$MANDRILL" \
+     -e "NODE_ENV=$NODE_ENV" \
+     -e "KEY_GA=$KEY_GA" \
+     -e "NEWRELIC=$NEWRELIC" \
+     -e "SESSION_SECRET=$SESSION_SECRET" \
+     -e "ENGI_BIND_PORT=$PORT" \
+     -p 127.0.0.1:$PORT:$PORT \
+     --link destroy-mongo:mongo \
+     --link destroy-rethink:rethink $FQDN:v1
+

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -132,7 +132,7 @@ gulp.task('js:player', ['clean:js:player', 'js:engine'], function(cb) {
 
 	// only uglify in production
 	if (process.env.NODE_ENV === 'production') {
-		playerPipe
+		playerPipe = playerPipe
 			.pipe(uglify().on('error', errorHandler))
 	}
 
@@ -141,10 +141,12 @@ gulp.task('js:player', ['clean:js:player', 'js:engine'], function(cb) {
 	.pipe(concat('player.min.js'))
 	.pipe(gulp.dest(path.join(__dirname, 'browser', 'dist')))
 	.on('error', errorHandler)
-	.on('end', function() {
-		pushPlayerToGrid()
-		.then(cb, cb)
-	})
+	.on('end', cb)
+})
+
+gulp.task('push', function(done) {
+	pushPlayerToGrid()
+		.then(done, done)
 })
 
 gulp.task('js', ['js:player'])
@@ -171,22 +173,22 @@ gulp.task('less360', ['clean:less360'], function() {
 
 gulp.task('watch', ['default'], function() {
 	gulp.watch('less/**/*', ['less', 'less360']);
-	gulp.watch(paths.js.player.concat(paths.js.engine), ['js:player'])
+	gulp.watch(paths.js.player.concat(paths.js.engine), ['push'])
 })
 
 gulp.task('watch:less360', function() {
 	gulp.watch('less/threesixty.less', ['less360']);
 });
 
-
 gulp.task('watch:less', function() {
 	gulp.watch('less/**/*', ['less'])
 })
 
-
 gulp.task('watch:player', function() {
-	gulp.watch(paths.js.player.concat(paths.js.engine), ['js:player'])
+	gulp.watch(paths.js.player.concat(paths.js.engine), ['push'])
 })
 
-gulp.task('default', ['less', 'less360', 'js']);
+gulp.task('golive', ['less', 'less360', 'js'])
+
+gulp.task('default', ['less', 'less360', 'js', 'push'])
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -118,16 +118,16 @@ gulp.task('clean:js', ['clean:js:player', 'clean:js:engine'])
 
 gulp.task('clean', ['clean:js'])
 
-gulp.task('js:engine', ['clean:js:engine'], function(cb) {
+gulp.task('js:engine', ['clean:js:engine'], function(done) {
 	gulp.src(paths.js.engine)
 	.pipe(concat.header(';\n'))
 	.pipe(concat('engine.js'))
 	.pipe(gulp.dest(path.join(__dirname, 'browser', 'dist')))
 	.on('error', errorHandler)
-	.on('end', cb)
+	.on('end', done)
 })
 
-gulp.task('js:player', ['clean:js:player', 'js:engine'], function(cb) {
+gulp.task('js:player', ['clean:js:player', 'js:engine'], function(done) {
 	var playerPipe = gulp.src(paths.js.engine.concat(paths.js.player))
 
 	// only uglify in production
@@ -141,12 +141,12 @@ gulp.task('js:player', ['clean:js:player', 'js:engine'], function(cb) {
 	.pipe(concat('player.min.js'))
 	.pipe(gulp.dest(path.join(__dirname, 'browser', 'dist')))
 	.on('error', errorHandler)
-	.on('end', cb)
+	.on('end', done)
 })
 
-gulp.task('push', function(done) {
+gulp.task('push', ['js:player'], function(done) {
 	pushPlayerToGrid()
-		.then(done, done)
+		.then(done, errorHandler)
 })
 
 gulp.task('js', ['js:player'])

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -173,7 +173,7 @@ gulp.task('less360', ['clean:less360'], function() {
 
 gulp.task('watch', ['default'], function() {
 	gulp.watch('less/**/*', ['less', 'less360']);
-	gulp.watch(paths.js.player.concat(paths.js.engine), ['push'])
+	gulp.watch(paths.js.player.concat(paths.js.engine), ['js:player', 'push'])
 })
 
 gulp.task('watch:less360', function() {
@@ -185,7 +185,7 @@ gulp.task('watch:less', function() {
 })
 
 gulp.task('watch:player', function() {
-	gulp.watch(paths.js.player.concat(paths.js.engine), ['push'])
+	gulp.watch(paths.js.player.concat(paths.js.engine), ['js:player', 'push'])
 })
 
 gulp.task('golive', ['less', 'less360', 'js'])


### PR DESCRIPTION
- moves deploy.sh into bin/deploy.sh
- use the same deploy.sh for all containers
- requires new ENV variables PORT and NODE_ENV
- add new `golive` gulp step for running container
- add new provisioning step to push player into gridfs