### PR TITLE
use Redis as message broker and backend store for EditorChannelServer; resolves #1101

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ENV HOME /root
 ENV NODE_ENV production
 ENV ENGI_BIND_IP 0.0.0.0
 ENV RETHINKDB_HOST rethink
+ENV REDIS redis
 ENV MONGODB mongodb://mongo:27017/vizor
 ENV GRIDFS mongodb://mongo:27017/vizor-assets
 EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Be sure to [watch the tutorials](http://bit.do/vizor) and [read the documentatio
 
 ### Installing
 
-Installing a local instance of Vizor requires [MongoDB](http://mongodb.org), [Redis](http://redis.ui) and either [node.js](https://nodejs.org) or [io.js](https://iojs.org/). To install the required packages, issue the following commands (on Mac using Homebrew):
+Installing a local instance of Vizor requires [MongoDB](http://mongodb.org), [Redis](http://redis.io) and either [node.js](https://nodejs.org) or [io.js](https://iojs.org/). To install the required packages, issue the following commands (on Mac using Homebrew):
 
 ```
     $ npm install && npm install -g gulp

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Be sure to [watch the tutorials](http://bit.do/vizor) and [read the documentatio
 
 ### Installing
 
-Installing a local instance of Vizor requires [MongoDB](http://mongodb.org), [RethinkDB](http://rethinkdb.com) and either [node.js](https://nodejs.org) or [io.js](https://iojs.org/). To install the required packages, issue the following commands (on Mac using Homebrew):
+Installing a local instance of Vizor requires [MongoDB](http://mongodb.org), [Redis](http://redis.ui) and either [node.js](https://nodejs.org) or [io.js](https://iojs.org/). To install the required packages, issue the following commands (on Mac using Homebrew):
 
 ```
     $ npm install && npm install -g gulp
@@ -38,7 +38,7 @@ Running the tests:
 
 ### Running
 
-1. Make sure MongoDB and RethinkDB are running.
+1. Make sure MongoDB and Redis are running.
 2. Run setup: ``` $ npm run setup ```
 3. Run the server: ``` $ npm start```
 4. Open in the browser: [http://localhost:8000/edit](http://localhost:8000/edit)

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -52,5 +52,5 @@ d run -d --name $FQDN \
      -e "ENGI_BIND_PORT=$PORT" \
      -p 127.0.0.1:$PORT:$PORT \
      --link mongo:mongo \
-     --link rethink:rethink $FQDN:v1
+     --link redis:redis $FQDN:v1
 

--- a/browser/scripts/stores/peopleStore.js
+++ b/browser/scripts/stores/peopleStore.js
@@ -115,6 +115,9 @@ PeopleStore.prototype.initialize = function() {
 	})
 	.on('leave', function(m) {
 		var person = that.people[m.id]
+		if (!person) // haven't seen them yet
+			return;
+
 		if (m.id === E2.app.channel.uid) {
 			that.empty()
 		} else {

--- a/browser/scripts/wschannel.js
+++ b/browser/scripts/wschannel.js
@@ -32,7 +32,7 @@ WebSocketChannel.prototype.connect = function(wsHost, wsPort, path, options) {
 	}
 
 	this.ws.onclose = function() {
-		console.warn('WsChannel disconnected', path, arguments)
+		console.warn('WsChannel disconnected')
 		that._state = 'disconnected'
 		that.emit('disconnected')
 	}

--- a/controllers/graphController.js
+++ b/controllers/graphController.js
@@ -65,12 +65,11 @@ function GraphController(s, gfs, mongoConnection) {
 	args.unshift(Graph);
 	AssetController.apply(this, args);
 
-	this.serialNumber = new SerialNumber(mongoConnection)
-	this.serialNumber.init()
-
 	this.redisClient = redis.createClient({
 		host: process.env.REDIS || 'localhost'
 	})
+
+	this.serialNumber = new SerialNumber(this.redisClient)
 
 	this.graphAnalyser = new GraphAnalyser(gfs)
 	this.previewImageProcessor = new PreviewImageProcessor()

--- a/lib/editorChannelServer.js
+++ b/lib/editorChannelServer.js
@@ -380,7 +380,7 @@ EditorChannelServer.prototype.dispatch = function() {
 
 	var dsp = that.dispatchQueue.shift()
 
-	this._serialNumber.next('serial:'+dsp.channel)
+	this._serialNumber.next(dsp.channel)
 	.then(function(serial) {
 		var payload = {
 			id: serial,

--- a/lib/editorChannelServer.js
+++ b/lib/editorChannelServer.js
@@ -2,9 +2,9 @@ var EventEmitter = require('events').EventEmitter
 var WebSocket = require('ws')
 var WebSocketServer = require('ws').Server
 var config = require('../config/config.json').server
-var r = require('rethinkdb')
 
 var mongoose = require('mongoose')
+var redis = require('redis')
 
 var User = require('../models/user')
 
@@ -68,29 +68,40 @@ EditorConnection.prototype.toJson = function() {
 	return json
 }
 
-function EditorChannelServer(rethinkConnection) {
+function EditorChannelServer() {
 	EventEmitter.call(this)
+
 	this.config = config
 	this.clients = {}
 	this.channels = {}
 	this.dispatchQueue = []
 
-	this._rethinkConnection = rethinkConnection
+	this.clusterNodeId = guid()
+
+	this._redisClient = this.createRedisClient()
+	this._redisSubscriber = this.createRedisClient()
+	this._redisPublisher = this.createRedisClient()
 }
 
 EditorChannelServer.prototype = Object.create(EventEmitter.prototype)
 
-EditorChannelServer.prototype.listen = function(httpServer) {
-	var that = this
+EditorChannelServer.prototype.createRedisClient = function() {
+	return redis.createClient({
+		host: process.env.REDIS || 'localhost'
+	})
+}
 
-	that.wss = new WebSocketServer( {
+EditorChannelServer.prototype.listen = function(httpServer) {
+	this.wss = new WebSocketServer( {
 		server: httpServer,
 		path: '/__editorChannel'
 	})
 
-	that.wss.on('connection', that.handleConnection.bind(that))
+	this.wss.on('connection', this.handleConnection.bind(this))
 
-	that.emit('ready')
+	this._redisSubscriber.on('message', this.handleRedisMessage.bind(this))
+
+	this.emit('ready')
 
 	console.log('EditorChannelServer ready')
 }
@@ -99,7 +110,10 @@ EditorChannelServer.prototype.close = function() {
 	this.wss.close()
 	this.clients = {}
 	this.channels = {}
-	this._rethinkConnection.close()
+
+	this._redisClient.end()
+	this._redisPublisher.end()
+	this._redisSubscriber.end()
 }
 
 EditorChannelServer.prototype.handleConnection = function(socket) {
@@ -163,8 +177,11 @@ EditorChannelServer.prototype.handleConnection = function(socket) {
 
 		that.clients[client.id] = client
 
-		socket.on('message', that.handleMessage.bind(that, client))
+		socket.on('message', that.handleSocketMessage.bind(that, client))
 		socket.on('close', that.onSocketClosed.bind(that, client))
+
+		// relay messages to the user from other nodes
+		that._redisSubscriber.subscribe(client.id)
 
 		that.send(client, {
 			kind: 'READY',
@@ -190,6 +207,9 @@ EditorChannelServer.prototype.handleConnection = function(socket) {
 
 EditorChannelServer.prototype.onSocketClosed = function(client) {
 	var that = this
+
+	this._redisSubscriber.unsubscribe(client.id)
+
 	client.channels.map(function(ch) {
 		that.leaveChannel(ch, client)
 	})
@@ -197,7 +217,39 @@ EditorChannelServer.prototype.onSocketClosed = function(client) {
 	delete this.clients[client.id]
 }
 
-EditorChannelServer.prototype.handleMessage = function(client, m) {
+EditorChannelServer.prototype.handleRedisMessage = function(channelName, payload) {
+	var that = this
+
+	// direct message to someone here
+	if (this.clients[channelName]) {
+		return this.sendString(this.clients[channelName], payload)
+	}
+
+	var message = JSON.parse(payload)
+
+	if (message.__cnid !== this.clusterNodeId) {
+		switch(message.kind) {
+			case 'join': // a join on another node
+				var members = this.channels[channelName]
+
+				// tell the joiner our member list
+				members.map(function(oc) {
+					var m = oc.toJson()
+					m.kind = 'join'
+					m.date = Date.now()
+					m.channel = channelName
+					that.sendToClientElsewhere(message.id, m)
+				})
+				break;
+		}
+	}
+
+	this.channels[channelName].map(function(client) {
+		that.sendString(client, payload)
+	})
+}
+
+EditorChannelServer.prototype.handleSocketMessage = function(client, m) {
 	var now = Date.now()
 
 	var message = JSON.parse(m)
@@ -255,30 +307,30 @@ EditorChannelServer.prototype.handleMessage = function(client, m) {
 			switch(message.actionType) {
 				case 'uiActiveGraphChanged':
 					client.activeGraphUid = message.activeGraphUid
-					return this.sendToChannel(message.channel, message, message.from)
+					return this.sendToChannel(message.channel, message)
 
 				case 'uiUserIdFollowed':
 					client.followUid = message.followUid
 					var target = this.clients[message.followUid]
 					if (target)
 						target.followers++
-					return this.sendToChannel(message.channel, message, message.from)
+					return this.sendToChannel(message.channel, message)
 				case 'uiUserIdUnfollowed':
 					client.followUid = null
 					var target = this.clients[message.followUid]
 					if (target)
 						target.followers--
-					return this.sendToChannel(message.channel, message, message.from)
+					return this.sendToChannel(message.channel, message)
 
 				case 'uiMouseMoved':
 					client.mousePosition = [message.x, message.y]
-					return this.sendToChannel(message.channel, message, message.from)
+					return this.sendToChannel(message.channel, message)
 	
 				case 'uiMouseClicked':
-					return this.sendToChannel(message.channel, message, message.from)
+					return this.sendToChannel(message.channel, message)
 
 				case 'uiPluginTransientStateChanged':
-					return this.sendToChannel(message.channel, message, message.from)
+					return this.sendToChannel(message.channel, message)
 
 				case 'uiChatMessageAdded':
 				case 'graphSnapshotted':
@@ -324,19 +376,18 @@ EditorChannelServer.prototype.dispatch = function() {
 	this.dispatching = true
 
 	var dsp = this.dispatchQueue.shift()
-
-	r.table('editlog')
-	.insert({
-		id: Date.now() + '' + localSerial++,
-		createdAt: Date.now(),
+	var id = Date.now() + '' + localSerial++
+	var payload = {
+		id: id,
 		name: dsp.channel,
 		from: dsp.from,
 		date: Date.now(),
 		log: JSON.stringify(dsp.message)
-	})
-	.run(this._rethinkConnection, {durability: 'hard'}, function(err, result) {
+	}
+
+	this._redisClient.zadd(dsp.channel, id, JSON.stringify(payload), function(err) {
 		if (err)
-			console.error(err.stack)
+			return console.error(err.stack)
 
 		that.dispatching = false
 
@@ -346,6 +397,11 @@ EditorChannelServer.prototype.dispatch = function() {
 				ack: dsp.ack
 			})
 		}
+
+		var message = dsp.message
+		message.id = payload.id
+		message.date = payload.date
+		that.sendToChannel(dsp.channel, message)
 
 		that.dispatch()
 	})
@@ -357,62 +413,35 @@ EditorChannelServer.prototype.tail = function(channelName, client, options) {
 	var lastEditSeen = options.lastEditSeen
 	var limit = options.limit
 
-	if (!that._rethinkConnection)
-		return;
+	function onInitialSet(err, initialSet) {
+		if (limit)
+			initialSet = initialSet.reverse()
 
-	var cmd = r.table('editlog')
+		initialSet.map(function(rowData) {
+			var row = JSON.parse(rowData)
 
-	if (lastEditSeen) {
-		cmd = cmd.filter(r.row('name').eq(channelName)
-			.and(r.row('id').gt(lastEditSeen)))
-	} else {
-		cmd = cmd.filter(r.row('name').eq(channelName))
-	}
+			if (lastEditSeen && row.id === lastEditSeen)
+				return;
 
-	cmd = cmd.orderBy('id')
-
-	if (limit)
-		cmd = cmd.orderBy(r.desc('id')).limit(limit)
-
-	cmd.run(that._rethinkConnection, function(err, cursor) {
-		if (err)
-			return clientErrorReporter.bind(this, client, err)
-
-		cursor.toArray(function(err, initialSet) {
-			if (limit)
-				initialSet = initialSet.reverse()
-
-			initialSet.map(function(row) {
-				var message = JSON.parse(row.log)
-				message.id = row.id
-				message.date = row.date
-				that.send(client, message)
-			})
-		})
-	})
-
-	cmd = r.table('editlog')
-	.changes()
-	.run(this._rethinkConnection, function(err, cursor) {
-		if (err)
-			return clientErrorReporter.bind(this, client, err)
-		
-		if (client.cursor)
-			client.cursor.close()
-
-		client.cursor = cursor
-
-		cursor.each(function(err, dsp) {
-			if (err)
-				return clientErrorReporter.bind(this, client, err)
-
-			var log = dsp.new_val.log
-
-			var message = JSON.parse(log)
-			message.id = dsp.new_val.id
+			var message = JSON.parse(row.log)
+			message.id = row.id
+			message.date = row.date
 			that.send(client, message)
 		})
-	})
+	}
+
+	if (limit) {
+		this._redisClient.zrevrangebyscore(channelName, 
+			'+inf', 
+			'0',
+			'LIMIT', '0', limit,
+			onInitialSet)
+	} else {
+		this._redisClient.zrangebyscore(channelName, 
+			lastEditSeen || '-inf', 
+			'+inf',
+			onInitialSet)
+	}
 }
 
 EditorChannelServer.prototype.joinChannel = function(channelName, readableName, client, message) {
@@ -424,11 +453,13 @@ EditorChannelServer.prototype.joinChannel = function(channelName, readableName, 
 	if (client.channels.indexOf(channelName) !== -1)
 		return
 
-	if (!this.channels[channelName])
+	if (!this.channels[channelName]) {
+		this._redisSubscriber.subscribe(channelName)
 		this.channels[channelName] = []
+	}
 
 	var members = this.channels[channelName]
-	
+
 	function doJoinChannel() {
 		// start listening to events from db
 		that.tail(channelName, client, {
@@ -440,7 +471,7 @@ EditorChannelServer.prototype.joinChannel = function(channelName, readableName, 
 		client.channels.push(channelName)
 		client.activeGraphUid = message.activeGraphUid
 
-		// tell others of joiner
+		// tell joiner of others (on this node)
 		members.map(function(oc) {
 			var m = oc.toJson()
 			m.kind = 'join'
@@ -451,9 +482,10 @@ EditorChannelServer.prototype.joinChannel = function(channelName, readableName, 
 
 		members.push(client)
 
-		// tell joiner of others
+		// tell others of joiner
 		var m = client.toJson()
 		m.kind = 'join'
+		m.date = Date.now()
 		m.channel = channelName
 		that.sendToChannel(channelName, m)
 
@@ -483,10 +515,7 @@ EditorChannelServer.prototype.leaveChannel = function(channelName, client) {
 		date: Date.now(),
 		username: client.username,
 		id: client.id
-	}, client.id)
-
-	if (client.cursor)
-		client.cursor.close()
+	})
 
 	this.channels[channelName] = this.channels[channelName].filter(function(cl) {
 		return (client.id !== cl.id)
@@ -500,21 +529,19 @@ EditorChannelServer.prototype.leaveChannel = function(channelName, client) {
 EditorChannelServer.prototype.sendToChannel = function(channelName, message, exceptId) {
 	var that = this
 
-	if (!this.channels[channelName])
-		return;
+	message.__cnid = this.clusterNodeId
 
-	this.channels[channelName].map(function(client) {
-		if (exceptId === client.id)
-			return;
-
-		that.send(client, message)
-	})
+	this._redisPublisher.publish(channelName, encode(message))
 
 	this.emit(channelName, message)
 }
 
+EditorChannelServer.prototype.sendToClientElsewhere = function(clientId, message) {
+	message.__cnid = this.clusterNodeId
+	this._redisPublisher.publish(clientId, encode(message))
+}
+
 EditorChannelServer.prototype.send = function(client, message) {
-	// console.log('send', message.actionType || message.kind, message.channel)
 	this.sendString(client, encode(message))
 }
 

--- a/lib/editorChannelServer.js
+++ b/lib/editorChannelServer.js
@@ -12,6 +12,7 @@ var secrets = require('../config/secrets')
 var sessions = require('client-sessions')
 
 var EditLog = require('../models/editLog')
+var SerialNumber = require('../lib/serialNumber')
 
 var minute = 60 * 1000;
 var hour = 60 * minute;
@@ -81,6 +82,8 @@ function EditorChannelServer() {
 	this._redisClient = this.createRedisClient()
 	this._redisSubscriber = this.createRedisClient()
 	this._redisPublisher = this.createRedisClient()
+
+	this._serialNumber = new SerialNumber(this._redisClient) 
 }
 
 EditorChannelServer.prototype = Object.create(EventEmitter.prototype)
@@ -375,35 +378,37 @@ EditorChannelServer.prototype.dispatch = function() {
 
 	this.dispatching = true
 
-	var dsp = this.dispatchQueue.shift()
-	var id = Date.now() + '' + localSerial++
-	var payload = {
-		id: id,
-		name: dsp.channel,
-		from: dsp.from,
-		date: Date.now(),
-		log: JSON.stringify(dsp.message)
-	}
+	var dsp = that.dispatchQueue.shift()
 
-	this._redisClient.zadd(dsp.channel, id, JSON.stringify(payload), function(err) {
-		if (err)
-			return console.error(err.stack)
-
-		that.dispatching = false
-
-		if (dsp.ack) {
-			that.send(that.clients[dsp.from], {
-				kind: 'ack',
-				ack: dsp.ack
-			})
+	this._serialNumber.next('serial:'+dsp.channel)
+	.then(function(serial) {
+		var payload = {
+			id: serial,
+			from: dsp.from,
+			date: Date.now(),
+			log: JSON.stringify(dsp.message)
 		}
 
-		var message = dsp.message
-		message.id = payload.id
-		message.date = payload.date
-		that.sendToChannel(dsp.channel, message)
+		that._redisClient.zadd(dsp.channel, serial, JSON.stringify(payload), function(err) {
+			if (err)
+				return console.error(err.stack)
 
-		that.dispatch()
+			that.dispatching = false
+
+			if (dsp.ack) {
+				that.send(that.clients[dsp.from], {
+					kind: 'ack',
+					ack: dsp.ack
+				})
+			}
+
+			var message = dsp.message
+			message.id = payload.id
+			message.date = payload.date
+			that.sendToChannel(dsp.channel, message)
+
+			that.dispatch()
+		})
 	})
 }
 

--- a/lib/editorChannelServer.js
+++ b/lib/editorChannelServer.js
@@ -526,7 +526,7 @@ EditorChannelServer.prototype.leaveChannel = function(channelName, client) {
 	})
 }
 
-EditorChannelServer.prototype.sendToChannel = function(channelName, message, exceptId) {
+EditorChannelServer.prototype.sendToChannel = function(channelName, message) {
 	var that = this
 
 	message.__cnid = this.clusterNodeId

--- a/lib/serialNumber.js
+++ b/lib/serialNumber.js
@@ -1,37 +1,24 @@
 var when = require('when')
 
 /**
- * uses MongoDB to get a serial number
+ * uses Redis to get a serial number
  **/
 
-function SerialNumber(mongo) {
-	this.mongo = mongo
+function SerialNumber(redisClient) {
+	this.redisClient = redisClient
 }
 
 SerialNumber.prototype.init = function() {
-	var that = this
-
-	this.mongo.collection('counters', function(err, coll) {
-		that._coll = coll
-	})
 }
 
 SerialNumber.prototype.next = function(key) {
 	var dfd = when.defer()
 
-	this._coll.findAndModify(
-		{ _id: key },
-		[[ '_id', 1 ]],
-		{ $inc: { seq: 1 } },
-		{
-			new: true,
-			upsert: true
-		},
-	function(err, doc) {
+	this.redisClient.incr(key, function(err, value) {
 		if (err)
 			return dfd.reject(err)
 
-		dfd.resolve(doc.seq)
+		dfd.resolve(value)
 	})
 
 	return dfd.promise
@@ -40,11 +27,24 @@ SerialNumber.prototype.next = function(key) {
 SerialNumber.prototype.get = function(key) {
 	var dfd = when.defer()
 
-	this._coll.findOne({ _id: key }, function(err, doc) {
+	this.redisClient.get(key, function(err, value) {
 		if (err)
 			return dfd.reject(err)
 
-		dfd.resolve(doc.seq)
+		dfd.resolve(value)
+	})
+
+	return dfd.promise
+}
+
+SerialNumber.prototype.set = function(key, value) {
+	var dfd = when.defer()
+
+	this.redisClient.set(key, value, function(err, value) {
+		if (err)
+			return dfd.reject(err)
+
+		dfd.resolve(value)
 	})
 
 	return dfd.promise
@@ -52,21 +52,15 @@ SerialNumber.prototype.get = function(key) {
 
 SerialNumber.prototype.__reset = function(key) {
 	var dfd = when.defer()
+	var that = this
 
-	this._coll.findAndModify(
-		{ _id: key },
-		[[ '_id', 1 ]],
-		{ $set: { seq: 0 } },
-		{
-			new: true,
-			upsert: true
-		},
-	function(err, doc) {
+	this.redisClient.set(key, 0, function(err) {
 		if (err)
 			return dfd.reject(err)
 
-		dfd.resolve(doc.seq)
+		dfd.resolve(that.get(key))
 	})
+
 
 	return dfd.promise
 }

--- a/lib/serialNumber.js
+++ b/lib/serialNumber.js
@@ -14,7 +14,7 @@ SerialNumber.prototype.init = function() {
 SerialNumber.prototype.next = function(key) {
 	var dfd = when.defer()
 
-	this.redisClient.incr(key, function(err, value) {
+	this.redisClient.incr('serial:'+key, function(err, value) {
 		if (err)
 			return dfd.reject(err)
 
@@ -27,7 +27,7 @@ SerialNumber.prototype.next = function(key) {
 SerialNumber.prototype.get = function(key) {
 	var dfd = when.defer()
 
-	this.redisClient.get(key, function(err, value) {
+	this.redisClient.get('serial:'+key, function(err, value) {
 		if (err)
 			return dfd.reject(err)
 
@@ -40,7 +40,7 @@ SerialNumber.prototype.get = function(key) {
 SerialNumber.prototype.set = function(key, value) {
 	var dfd = when.defer()
 
-	this.redisClient.set(key, value, function(err, value) {
+	this.redisClient.set('serial:'+key, value, function(err, value) {
 		if (err)
 			return dfd.reject(err)
 
@@ -54,11 +54,11 @@ SerialNumber.prototype.__reset = function(key) {
 	var dfd = when.defer()
 	var that = this
 
-	this.redisClient.set(key, 0, function(err) {
+	this.redisClient.set('serial:'+key, 0, function(err) {
 		if (err)
 			return dfd.reject(err)
 
-		dfd.resolve(that.get(key))
+		dfd.resolve(that.get('serial:'+key))
 	})
 
 

--- a/modelRoutes.js
+++ b/modelRoutes.js
@@ -15,7 +15,6 @@ module.exports =
 function modelRoutes(
 	app,
 	gfs,
-	rethinkConnection,
 	mongoConnection,
 	passportConf
 ){
@@ -40,7 +39,6 @@ function modelRoutes(
 	var graphController = new GraphController(
 		new GraphService(require('./models/graph'), gfs),
 		gfs,
-		rethinkConnection,
 		mongoConnection
 	);
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "Vizor",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "dependencies": {
     "async": {
       "version": "0.9.2",
@@ -183,7 +183,7 @@
           "dependencies": {
             "mime-types": {
               "version": "2.1.10",
-              "from": "mime-types@>=2.1.7 <2.2.0",
+              "from": "mime-types@>=2.1.9 <2.2.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
               "dependencies": {
                 "mime-db": {
@@ -286,74 +286,7 @@
                 "rimraf": {
                   "version": "2.5.2",
                   "from": "rimraf@>=2.2.8 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
-                  "dependencies": {
-                    "glob": {
-                      "version": "7.0.0",
-                      "from": "glob@>=7.0.0 <8.0.0",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz",
-                      "dependencies": {
-                        "inflight": {
-                          "version": "1.0.4",
-                          "from": "inflight@>=1.0.4 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                            }
-                          }
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        },
-                        "minimatch": {
-                          "version": "3.0.0",
-                          "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                          "dependencies": {
-                            "brace-expansion": {
-                              "version": "1.1.3",
-                              "from": "brace-expansion@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                              "dependencies": {
-                                "balanced-match": {
-                                  "version": "0.3.0",
-                                  "from": "balanced-match@>=0.3.0 <0.4.0",
-                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                                },
-                                "concat-map": {
-                                  "version": "0.0.1",
-                                  "from": "concat-map@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "once": {
-                          "version": "1.3.3",
-                          "from": "once@>=1.3.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                            }
-                          }
-                        },
-                        "path-is-absolute": {
-                          "version": "1.0.0",
-                          "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz"
                 }
               }
             },
@@ -432,7 +365,7 @@
               "dependencies": {
                 "mime-db": {
                   "version": "1.22.0",
-                  "from": "mime-db@>=1.6.0 <2.0.0",
+                  "from": "mime-db@>=1.21.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                 }
               }
@@ -461,7 +394,7 @@
               "dependencies": {
                 "mime-db": {
                   "version": "1.22.0",
-                  "from": "mime-db@>=1.6.0 <2.0.0",
+                  "from": "mime-db@>=1.21.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                 }
               }
@@ -497,7 +430,7 @@
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.9 <0.3.0",
+              "from": "async@>=0.2.6 <0.3.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
@@ -600,9 +533,9 @@
       }
     },
     "csso": {
-      "version": "1.6.1",
+      "version": "1.6.3",
       "from": "csso@>=1.3.11 <2.0.0",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-1.6.3.tgz",
       "dependencies": {
         "clap": {
           "version": "1.0.10",
@@ -611,7 +544,7 @@
           "dependencies": {
             "chalk": {
               "version": "1.1.1",
-              "from": "chalk@>=1.0.0 <2.0.0",
+              "from": "chalk@1.1.1",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
@@ -628,7 +561,7 @@
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
@@ -908,74 +841,7 @@
         "rimraf": {
           "version": "2.5.2",
           "from": "rimraf@>=2.2.8 <3.0.0",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "7.0.0",
-              "from": "glob@>=7.0.0 <8.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "minimatch": {
-                  "version": "3.0.0",
-                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.3",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0",
-                          "from": "balanced-match@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                }
-              }
-            }
-          }
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz"
         }
       }
     },
@@ -1018,7 +884,7 @@
           "dependencies": {
             "mime-types": {
               "version": "2.1.10",
-              "from": "mime-types@>=2.1.7 <2.2.0",
+              "from": "mime-types@>=2.1.9 <2.2.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
               "dependencies": {
                 "mime-db": {
@@ -1435,74 +1301,7 @@
         "rimraf": {
           "version": "2.5.2",
           "from": "rimraf@>=2.2.8 <3.0.0",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "7.0.0",
-              "from": "glob@>=7.0.0 <8.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "minimatch": {
-                  "version": "3.0.0",
-                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.3",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0",
-                          "from": "balanced-match@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                }
-              }
-            }
-          }
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz"
         }
       }
     },
@@ -3210,7 +3009,7 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
@@ -4337,7 +4136,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "readable-stream@>=1.0.31 <1.1.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
@@ -4391,7 +4190,7 @@
             },
             "chalk": {
               "version": "1.1.1",
-              "from": "chalk@1.1.1",
+              "from": "chalk@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
@@ -5119,7 +4918,7 @@
                       "dependencies": {
                         "escape-string-regexp": {
                           "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "from": "escape-string-regexp@>=1.0.4 <2.0.0",
                           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                         }
                       }
@@ -5556,7 +5355,7 @@
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "from": "inherits@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -5776,7 +5575,7 @@
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.1.4",
-          "from": "vinyl-sourcemaps-apply@>=0.1.1 <0.2.0-0",
+          "from": "vinyl-sourcemaps-apply@>=0.1.4 <0.2.0",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
           "dependencies": {
             "source-map": {
@@ -5870,7 +5669,7 @@
       "dependencies": {
         "gulp-util": {
           "version": "3.0.7",
-          "from": "gulp-util@>=3.0.0 <4.0.0",
+          "from": "gulp-util@>=3.0.0 <4.0.0-0",
           "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
           "dependencies": {
             "array-differ": {
@@ -5975,7 +5774,7 @@
                       "dependencies": {
                         "escape-string-regexp": {
                           "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "from": "escape-string-regexp@>=1.0.4 <2.0.0",
                           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                         }
                       }
@@ -6412,7 +6211,7 @@
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "from": "inherits@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -6501,7 +6300,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.3 <0.7.0",
+          "from": "through2@>=0.6.1 <1.0.0-0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
@@ -6581,7 +6380,7 @@
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.1.4",
-          "from": "vinyl-sourcemaps-apply@>=0.1.1 <0.2.0-0",
+          "from": "vinyl-sourcemaps-apply@>=0.1.4 <0.2.0",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
           "dependencies": {
             "source-map": {
@@ -8445,14 +8244,26 @@
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
         },
         "aws4": {
-          "version": "1.2.1",
+          "version": "1.3.1",
           "from": "aws4@>=1.2.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.3.1.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "2.7.3",
-              "from": "lru-cache@>=2.6.5 <3.0.0",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+              "version": "4.0.0",
+              "from": "lru-cache@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.0.tgz",
+              "dependencies": {
+                "pseudomap": {
+                  "version": "1.0.2",
+                  "from": "pseudomap@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+                },
+                "yallist": {
+                  "version": "2.0.0",
+                  "from": "yallist@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
+                }
+              }
             }
           }
         },
@@ -8779,7 +8590,7 @@
         },
         "mime-types": {
           "version": "2.1.10",
-          "from": "mime-types@>=2.1.7 <2.2.0",
+          "from": "mime-types@>=2.1.9 <2.2.0",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
           "dependencies": {
             "mime-db": {
@@ -8822,9 +8633,9 @@
       }
     },
     "rethinkdb": {
-      "version": "2.1.0",
-      "from": "rethinkdb@2.1.0",
-      "resolved": "https://registry.npmjs.org/rethinkdb/-/rethinkdb-2.1.0.tgz",
+      "version": "2.2.2",
+      "from": "rethinkdb@>=2.2.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/rethinkdb/-/rethinkdb-2.2.2.tgz",
       "dependencies": {
         "bluebird": {
           "version": "2.10.2",
@@ -8840,7 +8651,7 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
-          "from": "inherits@>=2.0.1 <2.1.0",
+          "from": "inherits@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "readable-stream": {
@@ -8936,7 +8747,7 @@
                   "dependencies": {
                     "align-text": {
                       "version": "0.1.4",
-                      "from": "align-text@>=0.1.3 <0.2.0",
+                      "from": "align-text@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                       "dependencies": {
                         "kind-of": {
@@ -8977,7 +8788,7 @@
                   "dependencies": {
                     "align-text": {
                       "version": "0.1.4",
-                      "from": "align-text@>=0.1.3 <0.2.0",
+                      "from": "align-text@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                       "dependencies": {
                         "kind-of": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -432,7 +432,7 @@
               "dependencies": {
                 "mime-db": {
                   "version": "1.22.0",
-                  "from": "mime-db@>=1.21.0 <2.0.0",
+                  "from": "mime-db@>=1.6.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                 }
               }
@@ -461,7 +461,7 @@
               "dependencies": {
                 "mime-db": {
                   "version": "1.22.0",
-                  "from": "mime-db@>=1.21.0 <2.0.0",
+                  "from": "mime-db@>=1.6.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                 }
               }
@@ -611,7 +611,7 @@
           "dependencies": {
             "chalk": {
               "version": "1.1.1",
-              "from": "chalk@1.1.1",
+              "from": "chalk@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
@@ -2213,7 +2213,7 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
@@ -2365,7 +2365,7 @@
               "dependencies": {
                 "clone": {
                   "version": "1.0.2",
-                  "from": "clone@>=1.0.0 <2.0.0",
+                  "from": "clone@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
                 }
               }
@@ -3210,7 +3210,7 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
@@ -5119,7 +5119,7 @@
                       "dependencies": {
                         "escape-string-regexp": {
                           "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                         }
                       }
@@ -5776,7 +5776,7 @@
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.1.4",
-          "from": "vinyl-sourcemaps-apply@>=0.1.4 <0.2.0",
+          "from": "vinyl-sourcemaps-apply@>=0.1.1 <0.2.0-0",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
           "dependencies": {
             "source-map": {
@@ -5870,7 +5870,7 @@
       "dependencies": {
         "gulp-util": {
           "version": "3.0.7",
-          "from": "gulp-util@>=3.0.0 <4.0.0-0",
+          "from": "gulp-util@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
           "dependencies": {
             "array-differ": {
@@ -5975,7 +5975,7 @@
                       "dependencies": {
                         "escape-string-regexp": {
                           "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                         }
                       }
@@ -6501,7 +6501,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.1 <1.0.0-0",
+          "from": "through2@>=0.6.3 <0.7.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
@@ -6581,7 +6581,7 @@
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.1.4",
-          "from": "vinyl-sourcemaps-apply@>=0.1.4 <0.2.0",
+          "from": "vinyl-sourcemaps-apply@>=0.1.1 <0.2.0-0",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
           "dependencies": {
             "source-map": {
@@ -8416,6 +8416,23 @@
       "version": "1.0.4",
       "from": "random-js@1.0.4",
       "resolved": "https://registry.npmjs.org/random-js/-/random-js-1.0.4.tgz"
+    },
+    "redis": {
+      "version": "2.4.2",
+      "from": "redis@>=2.4.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-2.4.2.tgz",
+      "dependencies": {
+        "double-ended-queue": {
+          "version": "2.1.0-0",
+          "from": "double-ended-queue@>=2.1.0-0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz"
+        },
+        "redis-commands": {
+          "version": "1.1.0",
+          "from": "redis-commands@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.1.0.tgz"
+        }
+      }
     },
     "request": {
       "version": "2.69.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "crypto-balance": "^0.0.4",
     "csso": "^1.3.11",
     "decompress-zip": "0.0.8",
+    "deepmerge": "~0.2.7",
     "del": "^0.1.3",
     "diy-handlebars-helpers": "^1.0.10",
     "errorhandler": "^1.1.1",
@@ -62,6 +63,7 @@
     "passport": "^0.2.0",
     "passport-local": "^1.0.0",
     "random-js": "1.0.4",
+    "redis": "^2.4.2",
     "request": "^2.40.0",
     "rethinkdb": "2.1.0",
     "stream-browserify": "^2.0.1",
@@ -70,7 +72,6 @@
     "validator": "^3.17.0",
     "when": "^3.5.1",
     "ws": "^0.4.31",
-    "deepmerge": "~0.2.7",
     "yauzl": "^2.3.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "random-js": "1.0.4",
     "redis": "^2.4.2",
     "request": "^2.40.0",
-    "rethinkdb": "2.1.0",
+    "rethinkdb": "^2.2.2",
     "stream-browserify": "^2.0.1",
     "temp": "~0.8.1",
     "uglify-js": "^2.4.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Vizor",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "",
   "main": "server.js",
   "dependencies": {

--- a/test/controllers/graph.js
+++ b/test/controllers/graph.js
@@ -31,7 +31,7 @@ describe('GraphController', function() {
 		var mongo = {
 			collection: function() {}
 		}
-		ctrl = new GraphController(svc, fs, {}, mongo)
+		ctrl = new GraphController(svc, fs, mongo)
 	})
 
 	it('calls save on graph post', function(done) {

--- a/test/integration/multiuserEditing.js
+++ b/test/integration/multiuserEditing.js
@@ -1,6 +1,5 @@
 var testId = rand()
 process.env.MONGODB = 'mongodb://localhost:27017/mutest'+testId
-process.env.RETHINKDB_NAME = 'test' + testId
 
 global.WebSocket = require('ws')
 global.EventEmitter = require('events').EventEmitter
@@ -11,12 +10,11 @@ var mongo = require('mongodb')
 var assert = require('assert')
 global.WebSocketChannel = require('../../browser/scripts/wschannel')
 var EditorChannel = require('../../browser/scripts/editorChannel')
-var r = require('rethinkdb')
 var session = require('client-sessions')
 var secrets = require('../../config/secrets');
 global.Flux = require('../../browser/vendor/flux')
 
-var setupRethinkDatabase = require('../../tools/setup').setupRethinkDatabase
+const redis = require('redis')
 
 global.window = {
 	location: { hostname: 'localhost', port: 8000 }
@@ -30,6 +28,12 @@ function rand() {
 
 var app = require('../../app.js')
 var agent = request.agent(app)
+
+function redisClient() {
+	return redis.createClient({
+		host: process.env.REDIS || 'localhost'
+	})
+}
 
 function createClient(channelName, lastEditSeen) {
 	var dispatcher = new Flux.Dispatcher()
@@ -62,23 +66,6 @@ function createClient(channelName, lastEditSeen) {
 	return chan
 }
 
-var rethinkConnection
-function setupDatabase() {
-	var dbName = process.env.RETHINKDB_NAME
-
-	return r.connect({
-		host: 'localhost',
-		port: 28015,
-		db: dbName
-	})
-	.then(function(conn) {
-		rethinkConnection = conn
-		return setupRethinkDatabase()
-	})
-	.error(function(err) {
-		throw err
-	})
-} 
 
 var s1, s2
 
@@ -119,15 +106,12 @@ describe('Multiuser', function() {
 		}
 
 		app.events.on('ready', function() {
-			setupDatabase()
-			.then(function() {
-				db = new mongo.Db('mutest'+testId, 
-					new mongo.Server('localhost', 27017),
-					{ safe: true })
+			db = new mongo.Db('mutest'+testId, 
+				new mongo.Server('localhost', 27017),
+				{ safe: true })
 
-				db.open(function() {
-					done()
-				})
+			db.open(function() {
+				done()
 			})
 		})
 	})
@@ -136,14 +120,7 @@ describe('Multiuser', function() {
 		mongoose.models = {}
 		mongoose.modelSchemas = {}
 		mongoose.connection.close()
-
-		r.dbDrop(process.env.RETHINKDB_NAME)
-			.run(rethinkConnection, function() {
-				db.dropDatabase()
-				db.close()
-				rethinkConnection.close()
-				done()
-			})
+		done()
 	})
 
 	beforeEach(function() {})
@@ -164,7 +141,7 @@ describe('Multiuser', function() {
 	})
 
 	it('sends acks', function(done) {
-		s1 = createClient('testack')
+		s1 = createClient('testack.' + Date.now())
 		s1.once('youJoined', function() {
 			s1.on('ackAbc', function() {
 				done()
@@ -275,9 +252,7 @@ describe('Multiuser', function() {
 				}
 			})
 		})
-
 	})
-
 
 	it('sends log on join, leave, join back', function(done) {
 		var channel = 'one-'+Math.random()
@@ -318,7 +293,6 @@ describe('Multiuser', function() {
 				s3.join(channel, channel, function() {})
 			})
 		})
-
 	})
 
 
@@ -362,6 +336,28 @@ describe('Multiuser', function() {
 					number: n
 				})
 			})
+		})
+	})
+
+
+	it('relays messages to user from cluster', function(done) {
+		var channel = 'test'+Math.random()
+		
+		s1 = createClient(channel)
+		var rc = redisClient()
+
+		s1.on('youJoined', function(you) {
+			s1.on('join', function(m) {
+				if (m.id === 'alice')
+					done()
+			})
+
+			// write to user's channel
+			rc.publish(s1.uid, JSON.stringify({
+				kind: 'join',
+				channel: channel,
+				id: 'alice'
+			}))
 		})
 	})
 

--- a/test/integration/multiuserEditing.js
+++ b/test/integration/multiuserEditing.js
@@ -295,7 +295,6 @@ describe('Multiuser', function() {
 		})
 	})
 
-
 	it('sends log from where left off', function(done) {
 		var channel = 'test'+Math.random()
 		
@@ -309,7 +308,7 @@ describe('Multiuser', function() {
 				firstId = m.id
 
 			lastId = m.id
-			
+
 			// wait until last message
 			if (m.number !== 2)
 				return;
@@ -319,8 +318,8 @@ describe('Multiuser', function() {
 			s3.once('join', function() {
 				// assert that we only get number 2
 				s3.dispatcher.register(function(m) {
-					assert.notEqual(m.number, 1)
-					assert.equal(m.id, lastId)
+					assert.equal(m.number, 2)
+					assert.equal(m.id, 2)
 					s3.close()
 					s3.once('disconnected', done)
 				})

--- a/test/integration/serialNumber.js
+++ b/test/integration/serialNumber.js
@@ -3,7 +3,7 @@ var assert = require('assert')
 var SerialNumber = require('../../lib/serialNumber')
 
 var secrets = require('../../config/secrets')
-var mongo = require('mongodb')
+var redis = require('redis')
 
 function rand() {
 	return Math.floor(Math.random() * 100000);
@@ -12,19 +12,15 @@ function rand() {
 var testId = rand()
 
 describe('SerialNumber', function() {
-	var sn, db
+	var sn, rc
 
 	before(function(done) {
-		db = new mongo.Db('sequence'+testId,
-			new mongo.Server('localhost', 27017),
-			{ safe: true }
-		);
-
-		db.open(done)
+		rc = redis.createClient()
+		rc.on('connect', done)
 	})
 
 	beforeEach(function(done) {
-		sn = new SerialNumber(db)
+		sn = new SerialNumber(rc)
 		sn.init()
 		sn.__reset('test')
 			.then(function(v) {
@@ -33,7 +29,7 @@ describe('SerialNumber', function() {
 	})
 
 	after(function() {
-		db.dropDatabase()
+		rc.end()
 	})
 
 	it('can get current value', function(done) {

--- a/tools/migration/0.7.0/0.7.0-redis.js
+++ b/tools/migration/0.7.0/0.7.0-redis.js
@@ -2,34 +2,73 @@ var fsPath = require('path')
 var secrets = require('../../../config/secrets')
 var r = require('rethinkdb')
 var redis = require('redis')
+var mongoose = require('mongoose')
 var when = require('when')
+var SerialNumber = require('../../../lib/serialNumber')
+
+var mongoDb, mongoColl, rethinkConnection
+var redisClient
+var sn
 
 function connect() {
 	var dfd = when.defer()
 
-	r.connect({
-		host: process.env.RETHINKDB_HOST || 'localhost',
-		port: 28015,
-		db: 'vizor'
-	}, function(err, conn) {
-		if (err)
-			dfd.reject(err)
-		dfd.resolve(conn)
+	mongoose.connect(secrets.db)
+
+	mongoose.connection.on('connected', function() {
+		mongoDb = mongoose.connection.db
+		mongoDb.collection('counters', function(err, coll) {
+			if (err) return dfd.reject(err)
+			mongoColl = coll
+
+			r.connect({
+				host: process.env.RETHINKDB_HOST || 'localhost',
+				port: 28015,
+				db: 'vizor'
+			}, function(err, conn) {
+				if (err)
+					dfd.reject(err)
+
+				rethinkConnection = conn
+		
+				redisClient = redis.createClient({
+					host: process.env.REDIS || 'localhost'
+				})
+
+				redisClient.on('connect', function() {
+					sn = new SerialNumber(redisClient)
+					dfd.resolve()
+				})
+			})
+		})
 	})
 
 	return dfd.promise
 }
 
-exports.execute = function() {
+function migrateSerials() {
 	var dfd = when.defer()
-	var rethinkConnection
-	var redisClient = redis.createClient({
-		host: process.env.REDIS || 'localhost'
+	mongoColl.find({}, function(err, counters) {
+		counters.each(function(err, counter) {
+			if (err) return dfd.reject(err)
+			if (!counter) return dfd.resolve()
+			console.log('   Set', counter._id, 'to', counter.seq)
+			sn.set(counter._id, counter.seq)
+		})
 	})
+	return dfd.promise
+}
+
+exports.execute = function() {
+	var total
+	var dfd = when.defer()
 
 	function done(err) {
+		mongoose.connection.close()
 		rethinkConnection.close()
 		redisClient.end()
+
+		console.log('All done')
 
 		if (err) {
 			console.error('ERROR: ', err.stack)
@@ -40,31 +79,59 @@ exports.execute = function() {
 	}
 
 	connect()
-	.then(function(c) {
-		rethinkConnection = c
-		r.table('editlog')
-		.run(rethinkConnection, function(err, cursor) {
-			if (err)
-				return done(err)
+	.then(function() {
+		console.log('Migrating serials')
+		return migrateSerials()
+	})
+	.then(function() {
+		console.log('Indexing')
+		return r.table('editlog').indexWait('name')
+		.run(rethinkConnection)
+	})
+	.then(function() {
+		console.log('Counting')
+		return r.table('editlog').count()
+		.run(rethinkConnection)
+	})
+	.then(function(t) {
+		total = t
 
-			cursor.toArray(function(err, logItems) {
-				when.map(logItems, function(row) {
-					var mapDfd = when.defer()
-					console.log(row.name, row.id)
-					redisClient.zadd(row.name, row.id, JSON.stringify(row), function(err) {
-						if (err)
-							return mapDfd.reject(err)
-						mapDfd.resolve()
-						return 
-					})
-					return mapDfd.promise
-				})
-				.then(function() {
-					done()
+		return r.table('editlog')
+		.orderBy({ index: 'name' })
+		.run(rethinkConnection)
+	})
+	.then(function(cursor) {
+		var i=0
+
+		return cursor.eachAsync(function(row) {
+			var idfd = when.defer()
+			sn.next('serial:'+row.name)
+			.then(function(serial) {
+				if (++i % 1000 === 0) {
+					console.log('    ', i, 'of', total, '-',
+						Math.round((i/total) * 100) + '%')
+				}
+
+				var payload = {
+					id: serial,
+					from: row.from,
+					date: row.date,
+					log: row.log
+				}
+
+				redisClient.zadd(row.name, serial, JSON.stringify(payload), function(err) {
+					if (err) return idfd.reject(err)
+					idfd.resolve()
 				})
 			})
+
+			return idfd.promise
 		})
 	})
+	.then(function() {
+		done()
+	})
+	.catch(done)
 
 	return dfd.promise
 }

--- a/tools/migration/0.7.0/0.7.0-redis.js
+++ b/tools/migration/0.7.0/0.7.0-redis.js
@@ -1,0 +1,73 @@
+var fsPath = require('path')
+var secrets = require('../../../config/secrets')
+var r = require('rethinkdb')
+var redis = require('redis')
+var when = require('when')
+
+function connect() {
+	var dfd = when.defer()
+
+	r.connect({
+		host: process.env.RETHINKDB_HOST || 'localhost',
+		port: 28015,
+		db: 'vizor'
+	}, function(err, conn) {
+		if (err)
+			dfd.reject(err)
+		dfd.resolve(conn)
+	})
+
+	return dfd.promise
+}
+
+exports.execute = function() {
+	var dfd = when.defer()
+	var rethinkConnection
+	var redisClient = redis.createClient({
+		host: process.env.REDIS || 'localhost'
+	})
+
+	function done(err) {
+		rethinkConnection.close()
+		redisClient.end()
+
+		if (err) {
+			console.error('ERROR: ', err.stack)
+			return dfd.reject(err)
+		}
+
+		dfd.resolve()
+	}
+
+	connect()
+	.then(function(c) {
+		rethinkConnection = c
+		r.table('editlog')
+		.run(rethinkConnection, function(err, cursor) {
+			if (err)
+				return done(err)
+
+			cursor.toArray(function(err, logItems) {
+				when.map(logItems, function(row) {
+					var mapDfd = when.defer()
+					console.log(row.name, row.id)
+					redisClient.zadd(row.name, row.id, JSON.stringify(row), function(err) {
+						if (err)
+							return mapDfd.reject(err)
+						mapDfd.resolve()
+						return 
+					})
+					return mapDfd.promise
+				})
+				.then(function() {
+					done()
+				})
+			})
+		})
+	})
+
+	return dfd.promise
+}
+
+if (require.main === module)
+	exports.execute()

--- a/tools/migration/0.7.0/0.7.0-redis.js
+++ b/tools/migration/0.7.0/0.7.0-redis.js
@@ -112,7 +112,7 @@ exports.execute = function() {
 
 		return cursor.eachAsync(function(row) {
 			var idfd = when.defer()
-			sn.next('serial:'+row.name)
+			sn.next(row.name)
 			.then(function(serial) {
 				if (++i % 1000 === 0) {
 					console.log('    ', i, 'of', total, '-',

--- a/tools/migration/0.7.0/0.7.0-redis.js
+++ b/tools/migration/0.7.0/0.7.0-redis.js
@@ -85,8 +85,10 @@ exports.execute = function() {
 	})
 	.then(function() {
 		console.log('Indexing')
-		return r.table('editlog').indexWait('name')
+		return r.table('editlog')
+		.indexCreate('name')
 		.run(rethinkConnection)
+		.error(function() {})
 	})
 	.then(function() {
 		console.log('Counting')

--- a/tools/migration/0.7.0/0.7.0-redis.js
+++ b/tools/migration/0.7.0/0.7.0-redis.js
@@ -91,6 +91,11 @@ exports.execute = function() {
 		.error(function() {})
 	})
 	.then(function() {
+		return r.table('editlog')
+		.indexWait('name')
+		.run(rethinkConnection)
+	})
+	.then(function() {
 		console.log('Counting')
 		return r.table('editlog').count()
 		.run(rethinkConnection)


### PR DESCRIPTION
- add pubsub channels via Redis
- store edit logs and chat in Redis instead of RethinkDB
- migration script to move edit logs & chat to Redis
- prepare to stop using RethinkDB altogether in the next release
