### PR TITLE
Limit the zoom level to 10 cm; resolves #1276

### DIFF
--- a/browser/vendor/three/EditorControls.js
+++ b/browser/vendor/three/EditorControls.js
@@ -72,7 +72,9 @@ THREE.EditorControls = function ( object, domElement ) {
 
 		delta.multiplyScalar( distance * 0.001 );
 
-		if ( delta.length() > distance ) return;
+		// Limit the zoom level to 10 cm
+		// But let the zoom level come out of distances smaller than that
+		if ( distance >= 0.01 && (distance + delta.z) <= 0.01 ) return;
 
 		delta.applyMatrix3( normalMatrix.getNormalMatrix( object.matrix ) );
 


### PR DESCRIPTION
Limit the zoom level to 10 cm and also allow the camera to zoom out of if below that limit.
No need to check if the mouse wheel zoom delta is bigger than current distance, because we won't go under it.