### PR TITLE
resolve #1375 - stretch slider node ui correctly

### DIFF
--- a/less/editor.less
+++ b/less/editor.less
@@ -766,7 +766,8 @@ div.p_id_slider_float_generator .p_content {
   .p_plugin {
 
 	table.slider-table {
-	  width: 181px;
+	  min-width: 181px;
+	  width: 100%;
 	  td {
 		padding: 0;
 		input, span {
@@ -785,6 +786,7 @@ div.p_id_slider_float_generator .p_content {
 		  color: #eee !important;
 		  background: rgba(0,0,0,0.3);
 		  text-align: center;
+		  border:1px solid transparent;
 		}
 
 


### PR DESCRIPTION
slider plugin UI stretches correctly with node

![screen shot 2016-03-23 at 09 47 51](https://cloud.githubusercontent.com/assets/14101296/13981491/4cf55388-f0dc-11e5-96ee-eb937006eec1.png)
