### PR TITLE
Include name of variable along with value

### DIFF
--- a/browser/scripts/player-run.js
+++ b/browser/scripts/player-run.js
@@ -65,7 +65,8 @@ window.addEventListener('message', function(e) {
 	switch(e.data.command) {
 		case 'getVariable':
 			send({
-				value: E2.app.player.getVariableValue(e.data.name)
+			name: e.data.name, 
+			value: E2.app.player.getVariableValue(e.data.name)
 			})
 			break;
 


### PR DESCRIPTION
provides context to the message recipient, before change the message doesn't include enough information for the recipient to know what that variable's value is being delivered.