### PR TITLE
resolves #1472; resolve 3d editor reverting to Move

### DIFF
--- a/browser/scripts/ui-core-statestore.js
+++ b/browser/scripts/ui-core-statestore.js
@@ -20,7 +20,7 @@ var UiState = function(persistentStorageRef, context) {
 	EventEmitter.apply(this, arguments)
 	var that = this
 
-	var persistentStorageKey = 'uiState104'
+	var persistentStorageKey = 'uiState105'
 
 	var defineProperty = function(obj, prop, options, callback) {
 		options = _.extend({
@@ -66,12 +66,12 @@ var UiState = function(persistentStorageRef, context) {
 
 	this._internal = {
 		modifyMode 	: uiModifyMode.move,			// does not autosave
+		modifyModeDefault: 	uiModifyMode.move,		//	''	, recall when modifications(keydown) end (keyup)
 		selectedObjects	: []						// [node, ...], does not autosave
 	}
 
 	var emitMain 		= makeEmitter(this)
 	defineGettersAndSetters(this, emitMain)
-
 
 	_.extend(this._internal, {
 		mode 		: uiMode.build,
@@ -421,6 +421,7 @@ UiState.prototype.getCopy = function() {
 	return {
 		mode: this.mode,
 		modifyMode: this.modifyMode,
+		modifyModeDefault: this.modifyModeDefault,
 		visible: this.visible,
 		viewCamera: this.viewCamera,
 		visibility: clone(this.visibility._internal),
@@ -443,7 +444,12 @@ UiState.prototype._apply = function(newState) {
 	var newVisibility = newState.visibility
 	if (newState.mode) 			internal.mode = newState.mode
 	if (newState.viewCamera) 	internal.viewCamera = newState.viewCamera
-	// modifyMode and selectedObjects ignored
+
+	if (newState.modifyModeDefault) 	{
+		internal.modifyModeDefault = newState.modifyModeDefault
+		internal.modifyMode = internal.modifyModeDefault
+	}
+	// selectedObjects ignored, and modifyMode set to default if one is given
 
 	// take values from supplied visibility, but default to current
 	for (var k in internalVisibility) {

--- a/browser/scripts/ui-core.js
+++ b/browser/scripts/ui-core.js
@@ -453,20 +453,18 @@ VizorUI.prototype.trackModifierKeysForWorldEditor = function() {
 	if (!anyModifiersPressed)
 		return anyModifiersPressed
 
-	switch (true) {
 		// 'cmd/ctrl' to rotate
-		case (this.flags.pressedMeta && !this.flags.pressedShift && !this.flags.pressedAlt):
-			this.state.modifyMode = uiModifyMode.rotate
-			break
 		// 'cmd/ctrl+shift' to scale
-		case (this.flags.pressedShift && this.flags.pressedMeta && (!this.flags.pressedAlt)):
-			this.state.modifyMode = uiModifyMode.scale
-			break
 		// 'shift' to move
-		case (this.flags.pressedShift && !this.flags.pressedAlt && !this.flags.pressedMeta):
+
+		if (flags.pressedMeta &&  !flags.pressedShift &&  !flags.pressedAlt)
+			this.state.modifyMode = uiModifyMode.rotate
+
+		else if (flags.pressedShift && flags.pressedMeta &&  !flags.pressedAlt)
+			this.state.modifyMode = uiModifyMode.scale
+
+		else if (flags.pressedShift &&  !flags.pressedAlt &&  !flags.pressedMeta)
 			this.state.modifyMode = uiModifyMode.move
-			break
-	}
 
 	return anyModifiersPressed
 }

--- a/browser/scripts/ui-core.js
+++ b/browser/scripts/ui-core.js
@@ -453,18 +453,18 @@ VizorUI.prototype.trackModifierKeysForWorldEditor = function() {
 	if (!anyModifiersPressed)
 		return anyModifiersPressed
 
-		// 'cmd/ctrl' to rotate
-		// 'cmd/ctrl+shift' to scale
-		// 'shift' to move
+	// 'cmd/ctrl' to rotate
+	// 'cmd/ctrl+shift' to scale
+	// 'shift' to move
 
-		if (flags.pressedMeta &&  !flags.pressedShift &&  !flags.pressedAlt)
-			this.state.modifyMode = uiModifyMode.rotate
+	if (flags.pressedMeta &&  !flags.pressedShift &&  !flags.pressedAlt)
+		this.state.modifyMode = uiModifyMode.rotate
 
-		else if (flags.pressedShift && flags.pressedMeta &&  !flags.pressedAlt)
-			this.state.modifyMode = uiModifyMode.scale
+	else if (flags.pressedShift && flags.pressedMeta &&  !flags.pressedAlt)
+		this.state.modifyMode = uiModifyMode.scale
 
-		else if (flags.pressedShift &&  !flags.pressedAlt &&  !flags.pressedMeta)
-			this.state.modifyMode = uiModifyMode.move
+	else if (flags.pressedShift &&  !flags.pressedAlt &&  !flags.pressedMeta)
+		this.state.modifyMode = uiModifyMode.move
 
 	return anyModifiersPressed
 }

--- a/browser/scripts/ui-core.js
+++ b/browser/scripts/ui-core.js
@@ -117,8 +117,8 @@ VizorUI.prototype._init = function(e2) {	// called by .init() in ui.js
 	document.body.addEventListener('keydown', this.onKeyDown.bind(this));
 	document.body.addEventListener('keyup', this.onKeyUp.bind(this));
 	document.addEventListener('keypress', this.onKeyPress.bind(this), true);	// first
-	window.addEventListener('blur', this._clearModifierKeys.bind(this));
-	window.addEventListener('focus', this._clearModifierKeys.bind(this));
+	window.addEventListener('blur', this._onWindowBlur.bind(this));
+	window.addEventListener('focus', this._onWindowFocus.bind(this));
 	window.addEventListener('resize', this.onWindowResize.bind(this));
 	e2.core.on('fullScreenChanged', this.onFullScreenChanged.bind(this));
 	e2.core.on('progress', this.updateProgressBar.bind(this));
@@ -407,12 +407,18 @@ VizorUI.prototype.isModalOpen = function() {
 
 /**** EVENT HANDLERS ****/
 
-VizorUI.prototype._clearModifierKeys = function() {	// blur
-	this.flags.pressedMeta = false;
-	this.flags.pressedAlt = false;
-	this.flags.pressedShift = false;
-	return true;
+VizorUI.prototype._onWindowBlur = function() {
+	// clear modifier keys
+	this.flags.pressedMeta = false
+	this.flags.pressedAlt = false
+	this.flags.pressedShift = false
+
+	// set default modify mode
+	this.state.modifyMode = this.state.modifyModeDefault
+
+	return true
 }
+VizorUI.prototype._onWindowFocus = VizorUI.prototype._onWindowBlur
 
 VizorUI.prototype._trackModifierKeys = function(e) {	// returns bool if any modifiers changed
 	var oldMeta = this.flags.pressedMeta,

--- a/browser/scripts/ui.js
+++ b/browser/scripts/ui.js
@@ -100,10 +100,12 @@ VizorUI.prototype.setupEventHandlers = function(e2, dom) {
 
 	var switchModifyMode = function(modifyMode){
 		return function(e){
-			e.preventDefault();
-			e.stopPropagation();
-			that.state.modifyMode = modifyMode;
-			return false;
+			e.preventDefault()
+			e.stopPropagation()
+			var state = that.state
+			state.modifyModeDefault = modifyMode
+			state.modifyMode = state.modifyModeDefault
+			return false
 		}
 	}
 	dom.btnMove.on('mousedown', switchModifyMode(uiModifyMode.move));


### PR DESCRIPTION
- makes modifier keys modify modify mode only temporarily until all modifier keys are released
- when any modifiers have changed but no modifiers are pressed, the default modify mode is restored.
- default modify mode is also applied when restoring state from persistent storage
