### PR TITLE
Resolves #1490 - fix triggering animate_xxx_on_trigger

### DIFF
--- a/browser/scripts/abstractAnimateValueOnTriggerPlugin.js
+++ b/browser/scripts/abstractAnimateValueOnTriggerPlugin.js
@@ -60,6 +60,7 @@ AbstractAnimateValueOnTriggerPlugin.prototype.create_ui = function() {
 }
 
 AbstractAnimateValueOnTriggerPlugin.prototype.reset = function() {
+	this.triggerOnNextUpdate = false
 	this.triggered = false
 	this.oneShot = false
 	this.duration = 1
@@ -72,10 +73,10 @@ AbstractAnimateValueOnTriggerPlugin.prototype.reset = function() {
 
 AbstractAnimateValueOnTriggerPlugin.prototype.update_input = function(slot, data) {
 	if (slot.name === 'trigger' && data && (!this.oneShot || !this.triggered)) {
-		this.triggered = true
-		this.startTime = this.abs_t
+		this.triggerOnNextUpdate = true
 	}
 	else if (slot.name === 'reset' && data) {
+		this.triggerOnNextUpdate = false
 		this.triggered = false
 	}
 	else if (slot.name === 'one-shot') {
@@ -103,6 +104,13 @@ AbstractAnimateValueOnTriggerPlugin.prototype.update_output = function(slot) {
 
 AbstractAnimateValueOnTriggerPlugin.prototype.update_state = function(updateContext) {
 	this.abs_t = updateContext.abs_t
+
+	if (this.triggerOnNextUpdate) {
+		this.triggered = true
+		this.startTime = this.abs_t
+		this.triggerOnNextUpdate = false
+	}
+
 	if (!this.triggered) {
 		this.value = this.lerpFunc(this.startValue, this.endValue, this.blendFunc.func(0))
 		this.always_update = false


### PR DESCRIPTION
This had broken when we introduced pausing - this.abs_t was not up to date when the trigger occurred

broken behaviour:
animate_float_on_trigger is inactive (update_state not getting called)
trigger causes update_input, which sets this.startTime to this.abs_t (which is out of date, due to no update_state occurring for a while)
update_state gets called but now this.abs_t is > (this.startTime + this.duration) so it appears that nothing happened.

new behaviour:
the state and times are only ever updated in update_state, so everything stays in sync