### PR TITLE
webvr boilerplate fixes

### DIFF
--- a/browser/scripts/ui-site.js
+++ b/browser/scripts/ui-site.js
@@ -224,6 +224,8 @@ var siteUI = new function() {
                     height: $homePlayerContainer.innerHeight()
                 }
             }
+
+			WebVRConfig.getContainerMeta = E2.app.calculateCanvasArea
 			onResize();
 		});
 
@@ -285,6 +287,10 @@ var siteUI = new function() {
             e.stopPropagation()
             return false
         })
+	}
+
+	this.isFullScreen = function() {
+		return !!(document.mozFullScreenElement || document.webkitFullscreenElement)
 	}
 
 	this.isInIframe = function() {

--- a/browser/scripts/ui/playerUI.js
+++ b/browser/scripts/ui/playerUI.js
@@ -452,7 +452,14 @@ VizorPlayerUI.prototype.suspendVRcamera = function() {
 }
 
 VizorPlayerUI.prototype.enableVRcamera = function() {
+	var that = this
 	this.vrCameraEnabled = true
+
+	E2.app.canInitiateCameraMove = function(e){
+		var isKeyboard = (e instanceof KeyboardEvent) && (e.target === document.body)
+		var isCanvas = (!isKeyboard) && E2.util.isCanvasInFocus(e)
+		return siteUI.isFullScreen() || that.vrCameraEnabled && (isKeyboard || isCanvas)
+	}
 }
 
 VizorPlayerUI.prototype.play = function() {

--- a/browser/vendor/borismus/webvr-manager.js
+++ b/browser/vendor/borismus/webvr-manager.js
@@ -565,6 +565,18 @@ WebVRManager.prototype.onBackClick_ = function() {
 };
 
 WebVRManager.prototype.getContainerDimensions = function() {	  // gm #896
+
+  // vizor.io gm #896
+  if (WebVRConfig && WebVRConfig.getContainerMeta) {
+     var meta = WebVRConfig.getContainerMeta()
+     var ret = {
+       width:   meta.width,
+       height:  meta.height
+     }
+    return ret
+  }
+  // end vizor.io gm #896
+
 	var container, width, height;
 	if (this.renderer.domElement) {
 	  container = this.renderer.domElement.parentNode;
@@ -585,21 +597,29 @@ WebVRManager.prototype.getContainerDimensions = function() {	  // gm #896
 	}
 }
 
+// vizor.io gm #896
+
 WebVRManager.prototype.resizeIfNeeded_ = function(camera) {
   // Only resize the canvas if it needs to be resized.
   var size = this.renderer.getSize();
-  if (size.width != window.innerWidth || size.height != window.innerHeight) {
-    this.resize_();
+
+  var d = this.getContainerDimensions();
+  if ( size.width != d.width || size.height != d.height) {
+    this.resize_(d, camera);
   }
 };
 
-WebVRManager.prototype.resize_ = function() {
-  this.effect.setSize(window.innerWidth, window.innerHeight);
-  if (this.camera) {
-    this.camera.aspect = window.innerWidth / window.innerHeight;
-    this.camera.updateProjectionMatrix();
+WebVRManager.prototype.resize_ = function(dimensions, camera) {
+  dimensions = dimensions || this.getContainerDimensions();
+  this.effect.setSize(dimensions.width, dimensions.height);
+  camera = camera || this.camera
+  if (camera) {
+    camera.aspect = dimensions.width / dimensions.height;
+    camera.updateProjectionMatrix();
   }
 };
+
+// end vizor.io gm #896
 
 WebVRManager.prototype.requestFullscreen_ = function() {
   var canvas = this.renderer.domElement;

--- a/browser/vendor/borismus/webvr-polyfill.js
+++ b/browser/vendor/borismus/webvr-polyfill.js
@@ -4467,6 +4467,12 @@ MouseKeyboardVRDisplay.prototype.getImmediatePose = function() {
 };
 
 MouseKeyboardVRDisplay.prototype.onKeyDown_ = function(e) {
+
+  // vizor.io gm #1504
+  if (E2 && E2.app && !E2.app.canInitiateCameraMove(e))
+      return true
+  // end vizor.io gm #1504
+
   // Track WASD and arrow keys.
   if (e.keyCode == 38) { // Up key.
     this.animatePhi_(this.phi_ + KEY_SPEED);
@@ -4515,6 +4521,11 @@ MouseKeyboardVRDisplay.prototype.animateKeyTransitions_ = function(angleName, ta
 };
 
 MouseKeyboardVRDisplay.prototype.onMouseDown_ = function(e) {
+  // vizor.io gm #1504
+  if (E2 && E2.app &&  !E2.app.canInitiateCameraMove(e))
+      return true
+  // end vizor.io gm #1504
+
   this.rotateStart_.set(e.clientX, e.clientY);
   this.isDragging_ = true;
 };
@@ -4536,9 +4547,22 @@ MouseKeyboardVRDisplay.prototype.onMouseMove_ = function(e) {
   this.rotateDelta_.subVectors(this.rotateEnd_, this.rotateStart_);
   this.rotateStart_.copy(this.rotateEnd_);
 
+  // vizor.io gm #896
+  var element = document.body,
+      height = element.clientHeight,
+      width = element.clientWidth
+
+  if (WebVRConfig && WebVRConfig.getContainerMeta) {
+     var meta = WebVRConfig.getContainerMeta()
+     height  = meta.height
+     width   = meta.width
+  }
+
   // Keep track of the cumulative euler angles.
-  this.phi_ += 2 * Math.PI * this.rotateDelta_.y / screen.height * MOUSE_SPEED_Y;
-  this.theta_ += 2 * Math.PI * this.rotateDelta_.x / screen.width * MOUSE_SPEED_X;
+  this.phi_ += 2 * Math.PI * this.rotateDelta_.y / height * MOUSE_SPEED_Y;
+  this.theta_ += 2 * Math.PI * this.rotateDelta_.x / width * MOUSE_SPEED_X;
+
+  // end vizor.io gm #896
 
   // Prevent looking too far up or down.
   this.phi_ = Util.clamp(this.phi_, -Math.PI/2, Math.PI/2);
@@ -5014,7 +5038,7 @@ FusionPoseSensor.prototype.onDeviceMotionChange_ = function(deviceMotion) {
   var deltaS = timestampS - this.previousTimestampS;
   if (deltaS <= Util.MIN_TIMESTEP || deltaS > Util.MAX_TIMESTEP) {
     console.warn('Invalid timestamps detected. Time step between successive ' +
-                 'gyroscope sensor samples is very small or not monotonic');
+                 'gyroscope sensor samples is very small or not monotonic ');
     this.previousTimestampS = timestampS;
     return;
   }
@@ -7500,6 +7524,12 @@ TouchPanner.prototype.resetSensor = function() {
 };
 
 TouchPanner.prototype.onTouchStart_ = function(e) {
+
+    // vizor.io gm #1504
+    if (E2 && E2.app &&  !E2.app.canInitiateCameraMove(e))
+        return
+    // end vizor.io gm #1504
+
   // Only respond if there is exactly one touch.
   if (e.touches.length != 1) {
     return;
@@ -7548,7 +7578,7 @@ module.exports = TouchPanner;
  */
 var Util = window.Util || {};
 
-Util.MIN_TIMESTEP = 0.001;
+Util.MIN_TIMESTEP = 0.0008;
 Util.MAX_TIMESTEP = 1;
 
 Util.base64 = function(mimeType, base64) {


### PR DESCRIPTION
resolves #1506 - wrong canvas dimensions on homepage
resolves #1504 - incorrect aspect ratio when switching between editor
cameras
fixes boilerplate regressions - canInitiateCameraMove and
getContainerDimensions now back where they were.