### PR TITLE
fixes to Web Socket connection setup

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -51,6 +51,8 @@ d run -d --name $FQDN \
      -e "ENGI_BIND_PORT=$PORT" \
      -e "KEY_MIXPANEL=$KEY_MIXPANEL" \
      -e "KEY_GA=$KEY_GA" \
+     -e "WSS_HOST=$WSS_HOST" \
+     -e "WSS_SECURE=$WSS_SECURE" \
      -p 127.0.0.1:$PORT:$PORT \
      --link mongo:mongo \
      --link redis:redis $FQDN:v1

--- a/browser/scripts/application.js
+++ b/browser/scripts/application.js
@@ -2137,20 +2137,11 @@ Application.prototype.setupEditorChannel = function() {
 		})
 	}
 
-	var secure = Vizor.releaseMode || window.location.protocol === 'https:'
-	var wsPort = window.location.port || (secure ? 443 : 80)
-	var wsHost
-
-	if (Vizor.releaseMode) {
-		wsHost = 'ws.' + window.location.hostname
-		wsPort = 443
-	} else {
-		wsHost = window.location.hostname
-	}
+	var wsUrl = this.determineWebSocketEndpoint('/__editorChannel')
 
 	if (!this.channel) {
 		this.channel = new E2.EditorChannel()
-		this.channel.connect(wsHost, wsPort)
+		this.channel.connect(wsUrl)
 		this.channel.on('ready', function() { 
 			that.setupChat()
 			that.peopleStore.initialize()
@@ -2162,6 +2153,23 @@ Application.prototype.setupEditorChannel = function() {
 	E2.ui.setPageTitle();
 	
 	return dfd.promise
+}
+
+Application.prototype.determineWebSocketEndpoint = function(path) {
+	var secure = Vizor.useSecureWebSocket || window.location.protocol === 'https:'
+	var wsPort = secure ? 443 : (window.location.port || 80)
+	var wsHost = window.location.hostname
+
+	if (Vizor.webSocketHost)
+		wsHost = Vizor.webSocketHost
+
+	if (secure)
+		wsPort = 443
+
+	var wsUrl = (secure ? 'wss': 'ws') + '://' + 
+	wsHost + ':' + wsPort + path
+
+	return wsUrl
 }
 
 E2.InitialiseEngi = function(vr_devices, loadGraphUrl) {

--- a/browser/scripts/editorChannel.js
+++ b/browser/scripts/editorChannel.js
@@ -98,21 +98,21 @@ EditorChannel.prototype.getWsChannel = function() {
 }
 
 var reconnecting = false
-EditorChannel.prototype.connect = function(wsHost, wsPort, options) {
+EditorChannel.prototype.connect = function(wsUrl, options) {
 	var that = this
 
 	this.kicked = false
 	this.connected = false
 	this.forking = false
 
-	this.reconnectFn = this.connect.bind(this, wsHost, wsPort, options)
+	this.reconnectFn = this.connect.bind(this, wsUrl, options)
 
 	E2.models.user.once('change', this.onLoginChanged.bind(this))
 
 	// listen to messages from network
 	this.wsChannel = new WebSocketChannel()
 	this.wsChannel
-		.connect(wsHost, wsPort, '/__editorChannel', options)
+		.connect(wsUrl, options)
 		.once('disconnected', function() {
 			if (!that.connected && !reconnecting)
 				return;

--- a/browser/scripts/wschannel.js
+++ b/browser/scripts/wschannel.js
@@ -10,18 +10,13 @@ function WebSocketChannel() {
 
 WebSocketChannel.prototype = Object.create(EventEmitter.prototype)
 
-WebSocketChannel.prototype.connect = function(wsHost, wsPort, path, options) {
+WebSocketChannel.prototype.connect = function(wsUrl, options) {
 	var that = this
-
-	path = path || '/__wschannel'
 
 	if (this._state === 'connected' || this._state === 'connecting')
 		return
 
 	this._state = 'connecting'
-
-	var wsUrl = (wsPort === 443 ? 'wss': 'ws') +
-		'://' + wsHost + ':' + wsPort + path
 
 	console.log('Connecting WebSocket', wsUrl)
 

--- a/browser/test/unit/wsendpoint.js
+++ b/browser/test/unit/wsendpoint.js
@@ -1,0 +1,42 @@
+global.E2 = {}
+var Application = require('../../scripts/application')
+
+var assert = require('assert')
+
+var f = Application.prototype.determineWebSocketEndpoint.bind({}, '/ep')
+
+describe('Determine WS connection options', function() {
+
+	beforeEach(function() {
+		global.Vizor = {
+			releaseMode: false
+		}
+		global.window = {
+			location: {
+				hostname: 'foo.vizor.test',
+				port: 8000,
+			}
+		}
+	})
+
+	it('uses unsecure by default', function() {
+		assert.equal('ws://foo.vizor.test:8000/ep', f())
+	})
+
+	it('uses secureWebSocket override', function() {
+		global.Vizor.useSecureWebSocket = true
+		assert.equal('wss://foo.vizor.test:443/ep', f())
+	})
+
+	it('uses webSocketHost and secureWebSocket overrides', function() {
+		global.Vizor.useSecureWebSocket = true
+		global.Vizor.webSocketHost = 'ws.ooh.vizor.test'
+		assert.equal('wss://ws.ooh.vizor.test:443/ep', f())
+	})
+
+	it('uses webSocketHost override', function() {
+		global.Vizor.webSocketHost = 'ws.ooh.vizor.test'
+		assert.equal('ws://ws.ooh.vizor.test:8000/ep', f())
+	})
+
+})

--- a/controllers/graphController.js
+++ b/controllers/graphController.js
@@ -232,7 +232,9 @@ function renderEditor(res, graph, hasEdits) {
 			layout: layout,
 			graph: graph,
 			hasEdits: hasEdits,
-			releaseMode: releaseMode
+			releaseMode: releaseMode,
+			webSocketHost: process.env.WSS_HOST || '',
+			useSecureWebSocket: releaseMode || !!process.env.WSS_SECURE
 		});
 	}
 

--- a/test/integration/multiuserEditing.js
+++ b/test/integration/multiuserEditing.js
@@ -39,10 +39,9 @@ function createClient(channelName, lastEditSeen) {
 	var dispatcher = new Flux.Dispatcher()
 	var chan = new EditorChannel(dispatcher)
 
-	var wsHost = window.location.hostname
-	var wsPort = window.location.port || 80
+	var wsUrl = 'ws://localhost:'+window.location.port+'/__editorChannel'
 
-	chan.connect(wsHost, wsPort, {
+	chan.connect(wsUrl, {
 		headers: {
 			'Cookie': 'vs070='+session.util.encode({
 				cookieName: 'vs070',

--- a/views/editor.handlebars
+++ b/views/editor.handlebars
@@ -245,7 +245,9 @@
 
 	window.Vizor = {
 		hideWebVRButton: true,
-		releaseMode: {{releaseMode}}
+		releaseMode: {{releaseMode}},
+		webSocketHost: '{{webSocketHost}}',
+		useSecureWebSocket: {{useSecureWebSocket}}
 	}
 
 	{{#if graph}}


### PR DESCRIPTION
- for production, use WSS_HOST=ws.vizor.io
- for dev hosts, use NODE_ENV=dev but WSS_SECURE=true
- for dev hosts with CloudFlare, use WSS_SECURE=false and WSS_HOST=ws.xxx.vizor.lol
- for localhost, default to non-secure localhost WS