### PR TITLE
Resolves #1648 - fix incorrect viewport resizing when using render to texture

### DIFF
--- a/browser/plugins/three_webgl_texture_renderer.plugin.js
+++ b/browser/plugins/three_webgl_texture_renderer.plugin.js
@@ -85,10 +85,7 @@
 	}
 
 	ThreeWebGLTextureRendererPlugin.prototype.update_state = function() {
-		// have to reset as the main renderer will override these
-
-		var oldPixelRatio = this.renderer.getPixelRatio()
-		this.renderer.setPixelRatio(1)
+		var renderBufferSize = this.renderer.getSize()
 
 		if (this.texture_dirty) {
 			this.create_texture()
@@ -98,7 +95,16 @@
 
 		this.renderer.setRenderTarget(this.texture)
 
-		if (!this.scene || !this.perspectiveCamera) {
+		// We have to reset pixel ratio and viewport size 
+		// as the main renderer will override these
+		// We can leave viewport size as the full canvas size 
+		// as the main renderer will set this again
+		var oldPixelRatio = this.renderer.getPixelRatio()
+		this.renderer.setPixelRatio(1)
+
+		this.renderer.setViewport(0, 0, renderBufferSize.width, renderBufferSize.height)
+
+     	if (!this.scene || !this.perspectiveCamera) {
 			this.renderer.clear()
 			this.renderer.setPixelRatio(oldPixelRatio)
 
@@ -108,10 +114,11 @@
 		// Render the scene through the manager.
 		this.renderer.render(this.scene, this.perspectiveCamera, this.texture)
 
+		this.renderer.setPixelRatio(oldPixelRatio)
+
 		// set render target to null as otherwise the next renderer will splat over
 		// the render target we just rendered
 		this.renderer.setRenderTarget(null)
-		this.renderer.setPixelRatio(oldPixelRatio)
 	}
 
 	ThreeWebGLTextureRendererPlugin.prototype.state_changed = function(ui) {


### PR DESCRIPTION
If render to texture was used in a graph, this resulted in the render viewport resizing to 50% width on every frame when in VR.