### PR TITLE
fix #1775 default breadcrumb separator

### DIFF
--- a/views/partials/breadcrumb.handlebars
+++ b/views/partials/breadcrumb.handlebars
@@ -1,10 +1,10 @@
 <div class="breadcrumb in">
 	{{#each crumbs}}
 		{{#unless @first}}
-			{{#with ../../options}}
+			{{#with ../options}}
 				{{#if useSeparator}}
-					{{#if ../separatorHtml}}
-						{{../../separatorHtml}}
+					{{#if separatorHtml}}
+						{{separatorHtml}}
 					{{else}}
 						<svg class="separator"><use xlink:href="#breadcrumb-separator"></use></svg>
 					{{/if}}


### PR DESCRIPTION
this is due to a previous bug in handlebars where {with} within an
{each} had the wrong context. i’ve checked for other instances of
similar bugs and did not find any.