### PR TITLE
match world editor and vr camera far planes

### DIFF
--- a/browser/plugins/three_vr_camera.plugin.js
+++ b/browser/plugins/three_vr_camera.plugin.js
@@ -13,8 +13,8 @@
 			{ name: 'rotation', dt: core.datatypes.VECTOR },
 			{ name: 'fov', dt: core.datatypes.FLOAT, def: this.defaultFOV },
 			{ name: 'aspectRatio', dt: core.datatypes.FLOAT, def: 1.0},
-			{ name: 'near', dt: core.datatypes.FLOAT, def: 0.001 },
-			{ name: 'far', dt: core.datatypes.FLOAT, def: 1000.0 },
+			{ name: 'near', dt: core.datatypes.FLOAT, def: 0.01 },
+			{ name: 'far', dt: core.datatypes.FLOAT, def: 10000.0 },
 			{
 				name:   'lock transform',
 				dt:     core.datatypes.BOOL,


### PR DESCRIPTION
"the camera settings might be ever so slightly different regarding back plane distance so that it changes when you switch overlays off. this fixes that (unless you override the far plane distance in the vr camera, in which case you’re out of luck)"