### PR TITLE
tab to editor and breadcrumb fixes

### DIFF
--- a/browser/scripts/application.js
+++ b/browser/scripts/application.js
@@ -940,6 +940,10 @@ Application.prototype.onDelete = function(e) {
 		return;
 
 	if (this.isWorldEditorActive()) {
+		if (!this.worldEditor.selectedEntityPatch)	{
+			E2.app.growl('could not delete')
+			return
+		}
 		var sn = this.worldEditor.selectedEntityNode
 		this.setActiveGraph(this.worldEditor.selectedEntityPatch.parent_graph)
 		this.selectedNodes = []
@@ -1334,7 +1338,8 @@ Application.prototype.markConnectionAsSelected = function(conn) {
 	this.selectedConnections.push(conn)
 }
 
-Application.prototype.clearSelection = function() {
+Application.prototype.clearSelection = function(alsoClearWorldEditor) {
+	alsoClearWorldEditor = (typeof alsoClearWorldEditor === 'undefined') ? true : !!alsoClearWorldEditor
 	var sn = this.selectedNodes;
 	var sc = this.selectedConnections;
 
@@ -1355,7 +1360,8 @@ Application.prototype.clearSelection = function() {
 
 	this.clearNodeSelection()
 
-	this.worldEditor.clearSelection()
+	if (alsoClearWorldEditor)
+		this.worldEditor.clearSelection()
 }
 
 Application.prototype.clearNodeSelection = function() {
@@ -1759,7 +1765,6 @@ Application.prototype.onGraphSelected = function(graph) {
 	this.scrollOffset[0] = this.scrollOffset[1] = 0
 
 	E2.dom.breadcrumb.children().remove()
-
 	E2.ui.buildBreadcrumb(E2.core.active_graph)
 
 	E2.core.active_graph.create_ui()

--- a/browser/scripts/ui-breadcrumb.js
+++ b/browser/scripts/ui-breadcrumb.js
@@ -3,6 +3,7 @@
  * known limitations - if used server-side it won't attach clickhandlers
  */
 var UIbreadcrumb = function(/* @var jQuery|null */ $existingContainer) {
+	var that = this
 	this.crumbs = []
 	this.clickHandlers = {}
 	this.withJquery = (typeof jQuery !== 'undefined')
@@ -25,6 +26,10 @@ var UIbreadcrumb = function(/* @var jQuery|null */ $existingContainer) {
 	} else {
 		this.container = null	// only produce html
 	}
+
+	Object.defineProperty(this, 'length', {
+		get: function(){return that.crumbs.length}
+	})
 }
 
 UIbreadcrumb.prototype.getTemplateData = function() {

--- a/browser/scripts/ui-core-statestore.js
+++ b/browser/scripts/ui-core-statestore.js
@@ -166,6 +166,7 @@ var UiState = function(persistentStorageRef, context) {
 	}
 	this.on('_internal:patch_editor', notifyBuildMode)
 	this.on('_internal:viewCamera', notifyBuildMode)
+	this.on('_internal:visible', notifyBuildMode)
 
 	defineProperty(this, 'visible', {
 		get: function() {
@@ -196,7 +197,6 @@ var UiState = function(persistentStorageRef, context) {
 			emitVisibility('floating_panels', v.floating_panels)
 			emitVisibility('patch_editor', v.patch_editor)
 			emitMain('visible', this.visible)
-			emitMain('mode', this.mode)
 			emitMain('selectedObjects', this.selectedObjects)
 		}
 	})

--- a/browser/scripts/ui/uiAbstractProperties.js
+++ b/browser/scripts/ui/uiAbstractProperties.js
@@ -20,17 +20,6 @@ var UIAbstractProperties = function UIAbstractProperties(domElement) {
 	// collects exposed properties. set at render-time
 	this.adapter = null
 
-	function isGraphNode(node) {
-		return node && node.plugin && (node.plugin.parentNode === node)
-	}
-
-	Object.defineProperty(this, 'selectedEditorObjectMeshNode', {
-		get: function() {
-			var p = E2.app.worldEditor.getSelectedObjectPlugin()
-			return (p && isGraphNode(p.parentNode)) ? p.parentNode : p
-		}
-	})
-
 	Object.defineProperty(this, 'selectedEditorObjectMeshPlugin', {
 		get: function() {
 			return E2.app.worldEditor.getSelectedObjectPlugin()
@@ -41,7 +30,7 @@ var UIAbstractProperties = function UIAbstractProperties(domElement) {
 	Object.defineProperty(this, 'selectedGraphNode', {
 		get: function() {
 			var sel = E2.ui.state.selectedObjects
-			return (sel &&  sel.length === 1 && isGraphNode(sel[0])) ? sel[0] : null
+			return (sel &&  sel.length === 1  && sel[0]) ? sel[0] : null
 		}
 	})
 
@@ -53,7 +42,6 @@ var UIAbstractProperties = function UIAbstractProperties(domElement) {
 	})
 
 	// convenience methods
-
 	Object.defineProperty(this, 'isValidObjectSelection', {
 		get: function() {
 			return !!this.selectedEditorObjectMeshPlugin

--- a/browser/scripts/ui/uiAbstractProperties.js
+++ b/browser/scripts/ui/uiAbstractProperties.js
@@ -20,10 +20,14 @@ var UIAbstractProperties = function UIAbstractProperties(domElement) {
 	// collects exposed properties. set at render-time
 	this.adapter = null
 
+	function isGraphNode(node) {
+		return node && node.plugin && (node.plugin.parentNode === node)
+	}
+
 	Object.defineProperty(this, 'selectedEditorObjectMeshNode', {
 		get: function() {
 			var p = E2.app.worldEditor.getSelectedObjectPlugin()
-			return p ? p.parentNode : p
+			return (p && isGraphNode(p.parentNode)) ? p.parentNode : p
 		}
 	})
 
@@ -37,7 +41,7 @@ var UIAbstractProperties = function UIAbstractProperties(domElement) {
 	Object.defineProperty(this, 'selectedGraphNode', {
 		get: function() {
 			var sel = E2.ui.state.selectedObjects
-			return (sel &&  sel.length === 1) ? sel[0] : null
+			return (sel &&  sel.length === 1 && isGraphNode(sel[0])) ? sel[0] : null
 		}
 	})
 

--- a/browser/scripts/ui/uiPropertiesNode.js
+++ b/browser/scripts/ui/uiPropertiesNode.js
@@ -65,7 +65,6 @@ UINodeProperties.prototype.getAdapter = function() {
 				var n = that.selectedGraphNode
 				if (!n) return null
 				E2.app.graphApi.renameNode(E2.core.active_graph, n, v);
-				E2.ui.refreshBreadcrumb()
 				return v
 			}
 		}

--- a/browser/scripts/ui/uiPropertiesObj3d.js
+++ b/browser/scripts/ui/uiPropertiesObj3d.js
@@ -26,8 +26,7 @@ var UIObjectProperties = function UIObjectProperties(domElement) {
 
 	this.controls = {}
 
-	// the world editor does not emit its own events
-	E2.ui.on('worldEditor:selectionSet', this.onObjectPicked.bind(this))
+	E2.app.worldEditor.on('selectionSet', this.onObjectPicked.bind(this))
 
 	this.emit('created')
 	this.render()

--- a/browser/test/unit/breadcrumb.js
+++ b/browser/test/unit/breadcrumb.js
@@ -1,0 +1,104 @@
+var assert = require('assert')
+var UIBreadcrumb = require('../../scripts/ui-breadcrumb')
+
+global.jQuery = function(){
+	var blank = ()=>{}
+	this._html = ''
+	this.html = function(html){return (typeof html !== 'undefined') ? (this._html = html) : this._html}
+
+	this.find = function(){
+		var _on = this._on = {}
+		return {on: (c,h)=>{_on[c]=h}, off:blank}
+	}
+}
+var $ = () => new jQuery()
+
+
+describe('UIBreadcrumb', function() {
+	var u
+	beforeEach(function () {
+		u = new UIBreadcrumb()
+	})
+
+	it('produces template data', function (done) {
+		var data = u.getTemplateData()
+		assert.equal(typeof (data.options), 'object', 'data must contain .options')
+		assert.equal(Array.isArray(data.crumbs), true, 'data must contain array of .crumbs')
+		u.add('test')
+		assert.equal(typeof data.crumbs[0], 'object', 'crumbs must be objects')
+
+		done()
+	})
+
+	it('adds crumbs', function (done) {
+		u.add('test')
+		u.add('test2', '#tx2')
+		u.add('test3', '#tx3', null, '$one$')
+
+		var crumbs = u.getTemplateData().crumbs
+
+		assert.equal(crumbs.length, 3, 'there must be three crumbs')
+		assert.equal(crumbs[0].text, 'test', 'must have correct text')
+		assert.equal(crumbs[1].link, '#tx2', 'must have correct link')
+		assert.equal(crumbs[2].uid, '$one$', 'must have correct uid')
+
+		done()
+	})
+
+
+	it('prepends crumbs', function (done) {
+		u.add('test')
+		var crumbs = u.getTemplateData().crumbs
+		assert.equal(crumbs[0].text, 'test', 'test crumb must come first')
+		u.prepend('prepend')
+		assert.equal(crumbs[0].text, 'prepend', 'prepend crumb must come first')
+		done()
+	})
+
+
+	it('adds a click handler', function(done){
+		var ch = function(){}
+		u.add('test4', '#tx4', ch, '$two$')
+		assert.equal(u.clickHandlers['$two$'], ch, 'must push clickHandler')
+		done()
+	})
+
+
+	it('counts crumbs right', function (done) {
+		var rnd = 5 + Math.round(Math.random()*100)
+		for (var i=rnd; i>0; i--) {
+			u.add('test'+i)
+		}
+		assert.equal(u.length, u.getTemplateData().crumbs.length, 'must have same length as crumbs')
+		assert.equal(u.length, rnd, 'must have correct length')
+
+		done()
+	})
+
+	it('distinguishes between crumbs that look the same', function (done) {
+		var ch1 = function(){}
+		var ch2 = function(){}
+		u.add('test', '#test', ch1, '$one$')
+		u.add('test', '#test', ch2, '$two$')
+		var cr = u.getTemplateData().crumbs
+		assert.equal(u.length, 2)
+		assert.equal(cr[0].text, cr[1].text)
+		assert.notEqual(cr[0].uid, cr[1].uid)
+		assert.equal(ch1, u.clickHandlers['$one$'])
+		assert.notEqual(ch1, u.clickHandlers['$two$'])
+		assert.equal(ch2, u.clickHandlers['$two$'])
+		done()
+	})
+
+	it('attaches', function(done){
+		u.add('sizz')
+		var container = $('#el')
+		var $j = u.render(container)
+		var template = $j.html
+		assert.deepEqual(u.container, container, 'must refer to container')
+		assert.equal(template('test'), 'test', 'must have default fallback template')
+		assert.equal(typeof u.container['_on']['click.breadcrumb'], 'function', 'must have a func inside onclick handlers')
+		done()
+	})
+
+})


### PR DESCRIPTION
 - resolves #1890 - revert `tab` behaviour to toggle patch editor to its last active graph
 - resolves #1891 - `shift+tab` to open patch editor to inside of selected object
 - resolves #907 - show vr camera in breadcrumb
 - resolves #1901 - refresh breadcrumb if node renamed by concurrent user
 - resolves #1900 - breadcrumb shows duplicated entries
 - fixes #1902 - mixpanel tracking program->build many times over
 - refines breadcrumb behaviour when selecting grouped objects
 - also adds a temporary fix for error on deleting of grouped objects from world editor