### PR TITLE
Release 20170131 - v0.15.1: Support audio on Safari and iOS

### DIFF
--- a/browser/plugins/url_audio_buffer_generator.plugin.js
+++ b/browser/plugins/url_audio_buffer_generator.plugin.js
@@ -1,4 +1,5 @@
 (function(){
+
 var UrlAudioBuffer = E2.plugins.url_audio_buffer_generator = function(core, node) {
 	Plugin.apply(this, arguments)
 	this.desc = 'Load an audio sample from an URL.'
@@ -25,14 +26,14 @@ UrlAudioBuffer.prototype.reset = function() {
 
 UrlAudioBuffer.prototype.create_ui = function() {
 	var inp = makeButton('Source', 'No audio selected.', 'url')
-	var self = this
+	var that = this
 
 	inp.click(function() {
-		FileSelectControl
-			.createAudioSelector(self.state.url)
-			.onChange(function(v) {
-				self.undoableSetState('url', v, self.state.url)
-			})
+		var fsc = FileSelectControl.createAudioSelector(that.state.url)
+		fsc.onChange(function(v) {
+			var actualFile = fsc.getFileMetadata(v)
+			that.undoableSetState('url', actualFile.path, that.state.url)
+		})
 	})
 
 	return inp
@@ -49,10 +50,23 @@ UrlAudioBuffer.prototype.update_state = function() {
 	if (!this.dirty)
 		return
 	
+	if (!this.state.url)
+		return
+
 	if (this.core.audioContext) {
+		var noextname = this.state.url.substring(0, this.state.url.lastIndexOf('.'))
+
+		if (E2.util.isMobile.iOS() || E2.util.isBrowser.Safari())
+			this.state.url = noextname + '.m4a'
+		else
+			this.state.url = noextname + '.ogg'
+
 		E2.core.assetLoader
 		.loadAsset('audiobuffer', this.state.url)
 		.then(function(buffer) {
+			if (!buffer)
+				return
+
 			that.buffer = buffer
 			that.updated = true
 		})

--- a/browser/scripts/file-select-control.js
+++ b/browser/scripts/file-select-control.js
@@ -89,6 +89,19 @@ FileSelectControl.prototype.files = function(files) {
 	return this
 }
 
+FileSelectControl.prototype.getFileMetadata = function(path) {
+	var meta 
+
+	this._fileList.get('files').some(function(file) {
+		if (file.url === path) {
+			meta = file
+			return true
+		}
+	})
+
+	return meta
+}
+
 FileSelectControl.prototype.selected = function(file) {
 	this._original = file
 	this._selected = file
@@ -130,7 +143,7 @@ FileSelectControl.prototype._renderFiles = function() {
 			if (!file.url)
 				file.url = file.path
 
-			file.selected = (file.path === that._selected)
+			file.selected = (file.url === that._selected)
 			if (!file.name)
 				file.name = file.path.substring(file.path.lastIndexOf('/')+1)
 			file.updatedAt = moment(file.updatedAt).fromNow()

--- a/browser/scripts/loaders/audioBufferLoader.js
+++ b/browser/scripts/loaders/audioBufferLoader.js
@@ -20,6 +20,8 @@ function AudioBufferLoader(url) {
 		E2.core.audioContext
 		.decodeAudioData(this.response, function(buffer) {
 			that.onLoaded(buffer)
+		}, function() {
+			that.onLoaded()
 		})
 	}
 

--- a/browser/scripts/util.js
+++ b/browser/scripts/util.js
@@ -204,7 +204,7 @@ E2.util = {
 			return (!!navigator.userAgent.match(/Chrome/)) || (!!navigator.userAgent.match(/CriOS/))
 		},
 		Safari: function () {
-			return !!navigator.userAgent.match(/Safari/)
+			return !E2.util.isBrowser.Chrome() && !!navigator.userAgent.match(/Safari/)
 		},
 		Edge: function () {
 			return !!navigator.userAgent.match(/Edge/)

--- a/browser/vendor/three/OBJLoader.js
+++ b/browser/vendor/three/OBJLoader.js
@@ -337,7 +337,7 @@ THREE.OBJLoader.prototype = {
 
 			} else {
 
-				console.error("Ignoring unexpected line: " + line)
+				// console.error("Ignoring unexpected line: " + line)
 
 			}
 

--- a/controllers/assetController.js
+++ b/controllers/assetController.js
@@ -2,6 +2,7 @@ var User = require('../models/user');
 var fsPath = require('path')
 var checksum = require('checksum')
 var assetHelper = require('../models/asset-helper')
+var streamFile = require('../lib/streamFile');
 
 function AssetController(modelClass, assetService, fs) {
 	this._model = modelClass
@@ -20,6 +21,21 @@ AssetController.prototype.validate = function(req, res, next) {
 		next()
 	})
 } 
+
+AssetController.prototype.streamFile = function(req, res, next) {
+	this._service.findByPath(req.path)
+	.then(asset => {
+		if (!asset)
+			return next()
+
+		var fakereq = {
+			path: asset.url,
+			headers: req.headers,
+			header: req.header,
+		}
+		return streamFile(fakereq, res, next, this._fs).catch(next)
+	})
+}
 
 // GET /:model
 AssetController.prototype.userIndex = function(req, res, next) {

--- a/lib/streamFile.js
+++ b/lib/streamFile.js
@@ -1,0 +1,71 @@
+var fsPath = require('path')
+
+function streamFile(req, res, next, gfs) {
+	var path = req.path.replace(/^\/data/, '')
+	var extname = fsPath.extname(path)
+	var model = path.split('/')[1]
+	var cacheControl = 'public'
+
+	switch(model) {
+		case 'dist':
+		case 'graph':
+			cacheControl = 'public'
+			break;
+	}
+
+	return gfs.stat(path)
+	.then(function(stat) {
+		if (!stat)
+			return res.status(404).send();
+
+		if (req.header('If-None-Match') === stat.md5)
+			return res.status(304).send();
+
+		if (req.headers.range) {
+			// stream partial file range
+			var parts = req.headers.range.replace(/bytes[=:]/, "").split("-");
+			var partialstart = parts[0];
+			var partialend = parts[1];
+
+			// start&end offset are inclusive, end is optional
+			var start = parseInt(partialstart, 10);
+			var end = partialend ? parseInt(partialend, 10) : (stat.length - 1);
+
+			var chunksize = (end - start) + 1;
+
+			res.writeHeader(206, {
+				'Content-Range': 'bytes ' + start + '-' + end + '/' + stat.length,
+				'Accept-Ranges': 'bytes',
+				'Cache-Control': cacheControl,
+				'Content-Length': chunksize,
+				'Expires': 'Sun, 17-Jan-2038 19:14:07 GMT',
+				'Content-Type': stat.contentType
+			});
+
+			var range = {startPos: start, endPos: end};
+			gfs.createReadStream(path, range)
+			.on('error', next)
+			.pipe(res);
+		} else {
+			// stream whole file in a single request
+			res.header('Content-Type', stat.contentType);
+
+			// only accept range-requests on audio and video
+			var rangeableTypes = ['.mp3', '.m4a', '.ogg', '.mp4', '.ogm', '.ogv']
+			if (rangeableTypes.indexOf(extname) !== -1)
+					res.header('Accept-Ranges', 'bytes')
+
+			res.header('ETag', stat.md5);
+			res.header('Content-Length', stat.length)
+			res.header('Cache-Control', cacheControl)
+			res.header('Expires', 'Sun, 17-Jan-2038 19:14:07 GMT')
+
+			gfs.createReadStream(path)
+			.on('error', next)
+			.pipe(res)
+
+		}
+	})
+}
+
+module.exports = streamFile

--- a/modelRoutes.js
+++ b/modelRoutes.js
@@ -1,3 +1,4 @@
+var fsPath = require('path')
 var temp = require('temp').track();
 var multer = require('multer');
 var path = require('path');
@@ -17,8 +18,7 @@ function requireAdminUser(req, res, next) {
 	res.sendStatus(401)
 }
 
-module.exports = 
-function modelRoutes(
+function setupDefaultRoutes(
 	app,
 	gfs,
 	mongoConnection,
@@ -371,6 +371,17 @@ function modelRoutes(
 		})
 	})
 
+	// stream a file by asset path 
+	// usually done by hash, but for audio, we need ogg and m4a on the same name
+	app.get('/:username/assets/:model/:filename', getController, function(req, res, next) {
+		requireController(req, res, function(err) {
+			if (err)
+				return next(err)
+
+			return req.controller.streamFile(req, res, next)
+		})
+	})
+
 	// list by tag for user
 	app.get('/:username/assets/:model/tag/:tag', requireController, function(req, res, next) {
 		req.controller.findByTagAndUsername(req, res, next)
@@ -409,4 +420,8 @@ function modelRoutes(
 		graphController.edit(req, res, next)
 	})
 
+}
+
+module.exports = {
+	setupDefaultRoutes: setupDefaultRoutes,
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Vizor",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "",
   "main": "server.js",
   "dependencies": {


### PR DESCRIPTION
- Support switching between ogg and m4a (iOS) depending on platform. To use this, upload the audio as ogg *and* m4a with the same name, and iOS/Safari will use the m4a.