### PR TITLE
Vizor2 teaser form submission tracking

### DIFF
--- a/browser/scripts/vizor2Teaser.js
+++ b/browser/scripts/vizor2Teaser.js
@@ -1,6 +1,20 @@
+// Scroll down button
 jQuery('.hero__scroll-down')
     .on('click', function(event) {
         event.preventDefault();
         var loc = jQuery('.introduction').offset().top;
         $("html, body").animate({ scrollTop: loc + 'px' }, 500);
     });
+
+
+// Registration form
+var registrationForm = document.querySelector('.register__form');
+registrationForm.addEventListener('submit', trackAndSubmit);
+function trackAndSubmit(event) {
+    registrationForm.removeEventListener('submit', trackAndSubmit);
+    event.preventDefault();
+    E2.track({ event: 'betaWaitingListSignup' })
+    setTimeout(function() {
+        registrationForm.submit();
+    }, 300); // Wait for 300ms before submitting to allow tracking to go through
+}

--- a/browser/scripts/vizor2Teaser.js
+++ b/browser/scripts/vizor2Teaser.js
@@ -1,6 +1,6 @@
 jQuery('.hero__scroll-down')
-.on('click', function(event) {
-    event.preventDefault();
-    var loc = jQuery('.introduction').offset().top;
-    $("html, body").animate({ scrollTop: loc + 'px' }, 500);
-});
+    .on('click', function(event) {
+        event.preventDefault();
+        var loc = jQuery('.introduction').offset().top;
+        $("html, body").animate({ scrollTop: loc + 'px' }, 500);
+    });

--- a/views/vizor2Teaser.handlebars
+++ b/views/vizor2Teaser.handlebars
@@ -23,6 +23,7 @@
     <link rel="icon" href="/favicon.ico?v=201608" />
     {{{css 'vizor2teaser'}}}
     <title>Build the Immersive Web with Vizor</title>
+    <script>{{> mixpanel}}</script>
 </head>
 <body>
 	{{> srv/gtm}}


### PR DESCRIPTION
The form submission has to be delayed to track it. Otherwise, the browser might cancel the requests to Mixpanel and/or Google Analytics APIs.

I used 300ms, because that's the value that Mixpanel JS API uses by default: https://mixpanel.com/help/reference/javascript-full-api-reference#mixpanel.track_forms

Tested in latest Chrome, Safari and Firefox on Mac.