### PR TITLE
Allow sending custom GA pageviews from graphs

### DIFF
--- a/browser/plugins/ga_pageview.plugin.js
+++ b/browser/plugins/ga_pageview.plugin.js
@@ -13,7 +13,7 @@ class GAPageViewPlugin extends Plugin {
     this.currentPage = null
   }
   update_input(slot, data) {
-    if (!data)
+    if (!data || typeof ga === 'undefined')
       return
 
     var locationHash = '#' + data

--- a/browser/plugins/ga_pageview.plugin.js
+++ b/browser/plugins/ga_pageview.plugin.js
@@ -1,0 +1,33 @@
+(function() {
+
+class GAPageViewPlugin extends Plugin {
+  constructor(core, node) {
+    super(core, node)
+    this.desc = 'Reports a page view (as a hash under the experience URL) to GA any time the input changes. Sets `page` first, then calls `pageview`.'
+    this.input_slots = [{
+      name: 'hash',
+      dt: core.datatypes.TEXT,
+      desc: 'The location hash to report to GA.'
+    }]
+    this.output_slots = []
+    this.currentPage = null
+  }
+  update_input(slot, data) {
+    if (!data)
+      return
+
+    var locationHash = '#' + data
+
+    if (this.currentPage === locationHash)
+      return
+
+    this.currentPage = locationHash
+
+    ga('clientTracker.set', 'page', window.location.pathname + locationHash)
+    ga('clientTracker.send', 'pageview')
+  }
+}
+
+E2.plugins.ga_pageview = GAPageViewPlugin
+
+})()

--- a/browser/plugins/google_analytics.plugin.js
+++ b/browser/plugins/google_analytics.plugin.js
@@ -1,0 +1,41 @@
+(function() {
+
+class GoogleAnalyticsPlugin extends Plugin {
+  constructor(core, node) {
+    super(core, node)
+    this.desc = 'Lets you track views and Vizor events in your own Google Analytics property.'
+    this.input_slots = [{
+      name: 'trackingId',
+      dt: core.datatypes.TEXT,
+      desc: 'Google Analytics property Tracking ID'
+    }]
+    this.output_slots = []
+    this.state = { trackingId: null }
+    this.currentId = null
+  }
+  update_input(slot, data) {
+    this.state.trackingId = data
+  }
+  update_state() {
+    this._createTracker()
+  }
+  _createTracker() {
+    if (!this.state.trackingId
+      || this.currentId === this.state.trackingId
+      || typeof ga === 'undefined')
+      return
+
+    ga('create', this.state.trackingId, 'auto', 'clientTracker')
+    this.currentId = this.state.trackingId
+  }
+  state_changed(ui) {
+    if (!ui)
+      return
+
+    this._createTracker()
+  }
+}
+
+E2.plugins.google_analytics = GoogleAnalyticsPlugin
+
+})()

--- a/browser/plugins/plugins.json
+++ b/browser/plugins/plugins.json
@@ -89,6 +89,11 @@
         "Environment Settings": "three_environment_settings"
     },
 
+    "ANALYTICS": {
+      "Google Analytics Tracking Property": "google_analytics",
+      "Google Analytics Page view": "ga_pageview"
+    },
+
     "3D GEOMETRY AND MESH TOOLS": {
         "Box": "three_geometry_box",
         "Circle": "three_geometry_circle",

--- a/browser/scripts/node-ui-enum.js
+++ b/browser/scripts/node-ui-enum.js
@@ -114,7 +114,7 @@ var uiNodeCategoryMap = {};
         'object_add' : 				c.value,
         'envelope_modulator' : 		c.value,
 
-		
+
 		'absolute_modulator' : c.math,
         'cos_modulator' 	: c.math,
         'exp_modulator' 	: c.math,
@@ -161,7 +161,7 @@ var uiNodeCategoryMap = {};
         'array_switch_modulator' : c.logic,
         'toggle_modulator'	: c.logic,
         'change_trigger'	: c.logic,
-		
+
         'three_gaze_clicker'	: c.interaction,
 		'three_clickable_object': c.interaction,
 		'key_press_generator'	: c.interaction,
@@ -186,6 +186,8 @@ var uiNodeCategoryMap = {};
         'assets_signal_failed_generator' : c.meta,
         'assets_started_generator' 		: c.meta,
         'assets_signal_started_generator' : c.meta,
+				'ga_pageview'					: c.meta,
+				'google_analytics'		: c.meta,
 
 		'runtime_event_write'			: c.meta,
 		'runtime_event_write_continuous': c.meta,
@@ -243,4 +245,3 @@ var uiPluginsThatAlwaysDisplayInline = [
 	'assets_started_generator',
 	'mouse_wheel_generator'
 ]
-

--- a/documentation/browser/plugins/ga_pageview.md
+++ b/documentation/browser/plugins/ga_pageview.md
@@ -1,0 +1,12 @@
+#Google Analytics Page view
+
+##Description
+Reports a page view (as a hash under the experience URL) to GA any time the input changes. Sets `page` first, then calls `pageview`.
+
+##Inputs
+###hash
+The location hash to report to GA.
+
+##Outputs
+##Detail
+

--- a/documentation/browser/plugins/google_analytics.md
+++ b/documentation/browser/plugins/google_analytics.md
@@ -1,0 +1,12 @@
+#Google Analytics Tracking Property
+
+##Description
+Lets you track views and Vizor events in your own Google Analytics property.
+
+##Inputs
+###trackingId
+Google Analytics property Tracking ID
+
+##Outputs
+##Detail
+

--- a/views/server/partials/gtm.handlebars
+++ b/views/server/partials/gtm.handlebars
@@ -9,7 +9,8 @@
 		if (evt.event)
 			mixpanel.track(evt.event, evt)
 
-		ga('clientTracker.send', 'event', evt.event, evt)
+		if (typeof ga === 'function')
+			ga('clientTracker.send', 'event', evt.event, evt)
 
 		dataLayer.push(evt)
 	}

--- a/views/server/partials/gtm.handlebars
+++ b/views/server/partials/gtm.handlebars
@@ -9,6 +9,8 @@
 		if (evt.event)
 			mixpanel.track(evt.event, evt)
 
+		ga('clientTracker.send', 'event', evt.event, evt)
+
 		dataLayer.push(evt)
 	}
 


### PR DESCRIPTION
Two new plugins: plugin for setting a custom Google Analytics Tracking ID, will create a `customTracker`; a plugin for sending `pageview` events as hashes under the experience URL.

![screen shot 2017-04-13 at 13 59 25](https://cloud.githubusercontent.com/assets/293426/25002119/7203ddd4-2051-11e7-81f5-7eda16bd5f9d.png)
