### PR TITLE
fix orientationchange ipad issues

### DIFF
--- a/browser/scripts/ui/playerUI.js
+++ b/browser/scripts/ui/playerUI.js
@@ -217,7 +217,7 @@ var VizorPlayerUI = function() {
 						$body.css({ height: (1.1*h) + 'px' })
 						$wrap.css({ bottom: (0.1*h) + 'px' })
 					}
-				}, 500)
+				}, 750)
 			}
 
 			$(window).on('orientationchange', allowExtraHeightOnLandscape)

--- a/browser/scripts/webVRAdapter.js
+++ b/browser/scripts/webVRAdapter.js
@@ -195,7 +195,10 @@ VizorWebVRAdapter.prototype.listenToBrowserEvents = function() {
 	var resizeHandler = this._onBrowserResize
 	if (resizeHandler) {
 		window.removeEventListener('resize', resizeHandler, true)
-		window.removeEventListener('orientationchange', resizeHandler, true)
+
+		if (!this.iOS)
+			window.removeEventListener('orientationchange', resizeHandler, true)
+
 		document.removeEventListener('webkitfullscreenchange', resizeHandler, true)
 		document.removeEventListener('mozfullscreenchange', resizeHandler, true)
 		document.removeEventListener('fullscreenchange', resizeHandler, true)
@@ -205,7 +208,8 @@ VizorWebVRAdapter.prototype.listenToBrowserEvents = function() {
 	}
 
 	window.addEventListener('resize', resizeHandler, true)
-	window.addEventListener('orientationchange', resizeHandler, true)
+	if (!this.iOS)
+		window.addEventListener('orientationchange', resizeHandler, true)
 	document.addEventListener('webkitfullscreenchange', resizeHandler, true)
 	document.addEventListener('mozfullscreenchange', resizeHandler, true)
 	document.addEventListener('fullscreenchange', resizeHandler, true)
@@ -256,7 +260,7 @@ VizorWebVRAdapter.prototype.onScroll = function() {
 
 VizorWebVRAdapter.prototype.onBrowserResize = function() {
 	var that = this
-	var timeout = (this.iOS) ? 200 : 10
+	var timeout = (this.iOS) ? 1000 : 10
 
 	function doResize() {
 		var isFullscreen = E2.util.isFullscreen()


### PR DESCRIPTION
 - webVRAdapter waits longer until orientationchange transition is well complete before resizing the viewport
 - playerUI waits until the orientationchange transition is complete before resizing document.body (allowExtraHeightOnLandscape) - this only affects iphone/ipodtouch
 - webVR adapter no longer binds on orientationchange on iOS, as that emits a resize too.
 
all in all - slower to respond, but more stable and one less handler.
tested on iOS 10.3.1, iPad Pro 9.7"
