### PR TITLE
Tweaked text, added 0-9 hotkeys

### DIFF
--- a/views/patch_editor/help_shortcuts.handlebars
+++ b/views/patch_editor/help_shortcuts.handlebars
@@ -6,76 +6,30 @@
 			<dl class="clearfix">
 				<dt>Build / Program</dt>
 				<dd>{{{toggleMode}}}</dd>
-
 				<dt>Editor / VR Camera</dt>
 				<dd>{{{toggleEditorCamera}}}</dd>
-
 				<dt>Enter fullscreen</dt>
 				<dd>{{{toggleFullScreen}}}</dd>
-
 				<dt>Exit fullscreen</dt>
 				<dd><kbd class="wide">Esc</kbd></dd>
-
 				<dt>Cut</dt>
 				<dd>{{{modMeta}}} + <kbd>x</kbd></dd>
-
 				<dt>Copy</dt>
 				<dd>{{{modMeta}}} + <kbd>c</kbd></dd>
-
 				<dt>Paste</dt>
 				<dd>{{{modMeta}}} + <kbd>v</kbd></dd>
-
 				<dt>Undo</dt>
 				<dd>{{{modMeta}}} + <kbd>z</kbd></dd>
-
 				<dt>Hide all panels</dt>
 				<dd>{{{toggleFloatingPanels}}}</dd>
-
 				<dt>Search patches</dt>
 				<dd>{{{focusPatchSearch}}} / {{{focusPatchSearchAlt}}}</dd>
-
-                <dt>Object inspector</dt>
+		                <dt>Object inspector</dt>
 				<dd>{{{openInspector}}}</dd>
-
 			</dl>
-		</div>
-		<div class="col right">
-			<h3>Build</h3>
-			<dl>
-				<dt>Move</dt>
-				<dd>{{{modifyModeMove}}}</dd>
 
-				<dt>Rotate</dt>
-				<dd>{{{modifyModeRotate}}} / {{{modMeta}}}</dd>
-
-				<dt>Scale</dt>
-				<dd>{{{modifyModeScale}}} / {{{modShift}}} + {{{modMeta}}}</dd>
-
-				<dt><abbr title="Sets the selected VR camera position to the current editor position">Zero VR camera</abbr></dt>
-				<dd>{{{moveVRCameraToEditorCamera}}}</dd>
-
-				<dt><abbr title="Switch camera to orthographic mode, i.e. remove all perspective from the camera view.">Orthographic Camera</abbr></dt>
-				<dd>{{{toggleWorldEditorOrthographicCamera}}}</dd>
-
-				<dt><abbr title="Toggle between rectangular and radial helper grids">Switch Grid Type</abbr></dt>
-				<dd>{{{toggleWorldEditorGrid}}}</dd>
-
-				<dt><abbr title="Toggle all build helper objects on/off">Toggle Helpers</abbr></dt>
-				<dd>{{{toggleEditorHelpers}}}</dd>
-
-                <dt><abbr title="Toggle local/global transform handles">Toggle Local Handles</abbr></dt>
-                <dd>{{{toggleWorldEditorLocalGlobalHandles}}}</dd>
-
-				<dt><abbr title="Align camera to primary axis. Holding shift will reverse camera direction.">Align Camera to Axis</abbr></dt>
-				<dd>{{{toggleWorldEditorXCamera}}} / {{{toggleWorldEditorYCamera}}} / {{{toggleWorldEditorZCamera}}}</dd>
-
-				<dt><abbr title="Frame the camera view around selected objects">Frame Selection</abbr></dt>
-				<dd>{{{frameViewToSelection}}}</dd>
-			</dl>
 			<h3>Program</h3>
-			<dl>
-				<dt>Handy patches</dt>
-				<dd><kbd>0</kbd> - <kbd>9</kbd></dd>
+			<dl class="clearfix">
 
 				<dt>Go to parent graph</dt>
 				<dd>{{{gotoParentGraph}}}</dd>
@@ -83,6 +37,56 @@
 				<dt>View source</dt>
 				<dd>{{{viewSource}}}</dd>
 			</dl>
+
+		</div>
+		<div class="col right">
+			<h3>Build</h3>
+			<dl class="clearfix">
+				<dt>Move</dt>
+				<dd>{{{modifyModeMove}}}</dd>
+				<dt>Rotate</dt>
+				<dd>{{{modifyModeRotate}}} / {{{modMeta}}}</dd>
+				<dt>Scale</dt>
+				<dd>{{{modifyModeScale}}} / {{{modShift}}} + {{{modMeta}}}</dd>
+				<dt><abbr title="Sets the selected VR camera position to the current editor position">Zero VR Cam</abbr></dt>
+				<dd>{{{moveVRCameraToEditorCamera}}}</dd>
+				<dt><abbr title="Switch camera to orthographic mode, i.e. remove all perspective from the camera view.">Orthographic Cam</abbr></dt>
+				<dd>{{{toggleWorldEditorOrthographicCamera}}}</dd>
+				<dt><abbr title="Toggle between rectangular and radial helper grids">Switch Grid Type</abbr></dt>
+				<dd>{{{toggleWorldEditorGrid}}}</dd>
+				<dt><abbr title="Toggle all build helper objects on/off">Helpers</abbr></dt>
+				<dd>{{{toggleEditorHelpers}}}</dd>
+				<dt><abbr title="Toggle local/global transform handles">Local Handles</abbr></dt>
+				<dd>{{{toggleWorldEditorLocalGlobalHandles}}}</dd>
+				<dt><abbr title="Align camera to primary axis. Holding shift will reverse camera direction.">Align Camera to Axis</abbr></dt>
+				<dd>{{{toggleWorldEditorXCamera}}} / {{{toggleWorldEditorYCamera}}} / {{{toggleWorldEditorZCamera}}}</dd>
+				<dt><abbr title="Frame the camera view around selected objects">Frame Selection</abbr></dt>
+				<dd>{{{frameViewToSelection}}}</dd>
+</dl>
+			<h3>Handy Keys</h3>
+			<dl class="clearfix">
+				<dt>Input</dt>
+				<dd><kbd>1</kbd></dd>
+				<dt>Nested Patch</dt>
+				<dd><kbd>2</kbd></dd>
+				<dt>Slider</dt>
+				<dd><kbd>3</kbd></dd>
+				<dt>Number</dt>
+				<dd><kbd>4</kbd></dd>
+				<dt>Float</dt>
+				<dd><kbd>5</kbd></dd>
+				<dt>Multiply Number</dt>
+				<dd><kbd>6</kbd></dd>
+				<dt>XYZ to Vector</dt>
+				<dd><kbd>7</kbd></dd>
+				<dt>Toggle</dt>
+				<dd><kbd>8</kbd></dd>
+				<dt>Knob</dt>
+				<dd><kbd>9</kbd></dd>
+				<dt>Output</dt>
+				<dd><kbd>0</kbd></dd>
+</dl>
+
 		</div>
 	</div>
 {{/with}}


### PR DESCRIPTION
Modified help text so each shortcut is on it's own row, aligned shortcut keys with text,
added Handy Keys (0-9) with accurate descriptions.
<img width="456" alt="ka___vizor" src="https://user-images.githubusercontent.com/4966687/27760214-9b2b490e-5e4a-11e7-8ac6-d8eed2f1a4ff.png">

This will address #1915 by @mattatgit 