### PR TITLE
Modified Scene and Nested Patch popup help

### DIFF
--- a/documentation/browser/plugins/graph.md
+++ b/documentation/browser/plugins/graph.md
@@ -1,7 +1,7 @@
 #Nested Patch
 
 ##Description
-A special patch that structures the graph by containing a group of other patches. View the contents of a Nested Patch by clicking the pencil on top right of the patch. All Nested Patches are purple.
+(Shortcut key: 2) - A patch (purple) can contain a group of other patches, called nesting. You can nest patches to build deep functionality or just to keep your graph clean and tidy. You can edit the contents of a nested patch by clicking the pencil at top right.
 
 ##Inputs
 ##Outputs

--- a/documentation/browser/plugins/graph.md
+++ b/documentation/browser/plugins/graph.md
@@ -1,7 +1,7 @@
 #Nested Patch
 
 ##Description
-(Shortcut key: 2) - A patch (purple) can contain a group of other patches, called nesting. You can nest patches to build deep functionality or just to keep your graph clean and tidy. You can edit the contents of a nested patch by clicking the pencil at top right.
+A Nested Patch can contain other patches. Nest patches to build complex functions or just to tidy things up. Click the pencil icon to edit. **Keyboard shortcut: 2**
 
 ##Inputs
 ##Outputs

--- a/documentation/browser/plugins/three_scene.md
+++ b/documentation/browser/plugins/three_scene.md
@@ -1,7 +1,7 @@
 #Scene
 
 ##Description
-THREE.js Scene
+Anything connected here will appear in your Vizor scene. Click the port and drag to disconnect or select the patch and hit delete.
 
 ##Inputs
 ###environment


### PR DESCRIPTION
As regards @mattatgit 's #819 issue, tooltips for Scene and Nested Patch have been updated with "better info".

<img width="288" alt="27760374-e7e65c6c-5e4e-11e7-89d5-8a9cfb3c8e4b" src="https://user-images.githubusercontent.com/4966687/27760435-a901abf4-5e4f-11e7-907f-65aafd9bb049.png">
<img width="270" alt="27760386-20b42038-5e4f-11e7-8ab6-7342d27a171f" src="https://user-images.githubusercontent.com/4966687/27760436-aac1666e-5e4f-11e7-807e-37a164baf00f.png">

NOTE: these are works in progress, if Matt likes them, we could merge these in. Still need to figure out how to force the next row in these descriptions, probably not <br>