### PR TITLE
"Keyboard shortcut" added to descriptions

### DIFF
--- a/documentation/browser/plugins/const_float_generator.md
+++ b/documentation/browser/plugins/const_float_generator.md
@@ -1,7 +1,7 @@
 #Number
 
 ##Description
-Emits a float constant specified in an input field. If an invalid string in entered, the field is reset to the previous value.
+Emits a float constant specified in an input field. If an invalid string in entered, the field is reset to the previous value.<br><br>Keyboard shortcut `4`
 
 ##Inputs
 ##Outputs

--- a/documentation/browser/plugins/const_float_generator.md
+++ b/documentation/browser/plugins/const_float_generator.md
@@ -1,7 +1,7 @@
 #Number
 
 ##Description
-Emits a float constant specified in an input field. If an invalid string in entered, the field is reset to the previous value.<br><br>Keyboard shortcut `4`
+Emits a float constant specified in an input field. If an invalid string in entered, the field is reset to the previous value.<br><br>Keyboard shortcut&nbsp;&nbsp;&nbsp;`4`
 
 ##Inputs
 ##Outputs

--- a/documentation/browser/plugins/float_display.md
+++ b/documentation/browser/plugins/float_display.md
@@ -1,7 +1,7 @@
 #Float
 
 ##Description
-Display the supplied float value on the plugin surface.<br><br>Keyboard shortcut `5`
+Display the supplied float value on the plugin surface.<br><br>Keyboard shortcut&nbsp;&nbsp;&nbsp;`5`
 
 ##Inputs
 ###float

--- a/documentation/browser/plugins/float_display.md
+++ b/documentation/browser/plugins/float_display.md
@@ -1,7 +1,7 @@
 #Float
 
 ##Description
-Display the supplied float value on the plugin surface.
+Display the supplied float value on the plugin surface.<br><br>Keyboard shortcut `5`
 
 ##Inputs
 ###float

--- a/documentation/browser/plugins/graph.md
+++ b/documentation/browser/plugins/graph.md
@@ -1,7 +1,7 @@
 #Nested Patch
 
 ##Description
-A Nested Patch can contain other patches. Nest patches to build complex functions or just to tidy things up. Click the pencil icon to edit.<br><br>Keyboard shortcut `2`
+A Nested Patch can contain other patches. Nest patches to build complex functions or just to tidy things up. Click the pencil icon to edit.<br><br>Keyboard shortcut&nbsp;&nbsp;&nbsp;`2`
 
 ##Inputs
 ##Outputs

--- a/documentation/browser/plugins/graph.md
+++ b/documentation/browser/plugins/graph.md
@@ -1,7 +1,7 @@
 #Nested Patch
 
 ##Description
-A Nested Patch can contain other patches. Nest patches to build complex functions or just to tidy things up. Click the pencil icon to edit. **Keyboard shortcut: 2**
+A Nested Patch can contain other patches. Nest patches to build complex functions or just to tidy things up. Click the pencil icon to edit.<br><br>Keyboard shortcut `2`
 
 ##Inputs
 ##Outputs

--- a/documentation/browser/plugins/input_proxy.md
+++ b/documentation/browser/plugins/input_proxy.md
@@ -1,7 +1,7 @@
 #Input proxy
 
 ##Description
-Create a new type-less slot to route data into the current graph from its parent. When connected to a slot, it will assume its type until disconnected. Renaming this plugin will rename the corresponding parent slot.
+Create a new type-less slot to route data into the current graph from its parent. When connected to a slot, it will assume its type until disconnected. Renaming this plugin will rename the corresponding parent slot.<br><br>Keyboard shortcut `1`
 
 ##Inputs
 ##Outputs

--- a/documentation/browser/plugins/input_proxy.md
+++ b/documentation/browser/plugins/input_proxy.md
@@ -1,7 +1,7 @@
 #Input proxy
 
 ##Description
-Create a new type-less slot to route data into the current graph from its parent. When connected to a slot, it will assume its type until disconnected. Renaming this plugin will rename the corresponding parent slot.<br><br>Keyboard shortcut `1`
+Create a new type-less slot to route data into the current graph from its parent. When connected to a slot, it will assume its type until disconnected. Renaming this plugin will rename the corresponding parent slot.<br><br>Keyboard shortcut&nbsp;&nbsp;&nbsp;`1`
 
 ##Inputs
 ##Outputs

--- a/documentation/browser/plugins/knob_float_generator.md
+++ b/documentation/browser/plugins/knob_float_generator.md
@@ -1,7 +1,7 @@
 #Knob
 
 ##Description
-Emits a user controllable float value between 0 and 1.
+Emits a user controllable float value between 0 and 1.<br><br>Keyboard shortcut `9`
 
 ##Inputs
 ##Outputs

--- a/documentation/browser/plugins/knob_float_generator.md
+++ b/documentation/browser/plugins/knob_float_generator.md
@@ -1,7 +1,7 @@
 #Knob
 
 ##Description
-Emits a user controllable float value between 0 and 1.<br><br>Keyboard shortcut `9`
+Emits a user controllable float value between 0 and 1.<br><br>Keyboard shortcut&nbsp;&nbsp;&nbsp;`9`
 
 ##Inputs
 ##Outputs

--- a/documentation/browser/plugins/multiply_modulator.md
+++ b/documentation/browser/plugins/multiply_modulator.md
@@ -1,7 +1,7 @@
 #Multiply number
 
 ##Description
-Multiplies the two supplied values and emits the result.
+Multiplies the two supplied values and emits the result.<br><br>Keyboard shortcut `6`
 
 ##Inputs
 ###a

--- a/documentation/browser/plugins/multiply_modulator.md
+++ b/documentation/browser/plugins/multiply_modulator.md
@@ -1,7 +1,7 @@
 #Multiply number
 
 ##Description
-Multiplies the two supplied values and emits the result.<br><br>Keyboard shortcut `6`
+Multiplies the two supplied values and emits the result.<br><br>Keyboard shortcut&nbsp;&nbsp;&nbsp;`6`
 
 ##Inputs
 ###a

--- a/documentation/browser/plugins/output_proxy.md
+++ b/documentation/browser/plugins/output_proxy.md
@@ -1,7 +1,7 @@
 #Output proxy
 
 ##Description
-Create a new type-less slot to route data out of the current graph to its parent. When connected to a slot, it will assume its type until disconnected. Renaming this plugin will rename the corresponding parent slot.<br><br>Keyboard shortcut `0`
+Create a new type-less slot to route data out of the current graph to its parent. When connected to a slot, it will assume its type until disconnected. Renaming this plugin will rename the corresponding parent slot.<br><br>Keyboard shortcut&nbsp;&nbsp;&nbsp;`0`
 
 ##Inputs
 ##Outputs

--- a/documentation/browser/plugins/output_proxy.md
+++ b/documentation/browser/plugins/output_proxy.md
@@ -1,7 +1,7 @@
 #Output proxy
 
 ##Description
-Create a new type-less slot to route data out of the current graph to its parent. When connected to a slot, it will assume its type until disconnected. Renaming this plugin will rename the corresponding parent slot.
+Create a new type-less slot to route data out of the current graph to its parent. When connected to a slot, it will assume its type until disconnected. Renaming this plugin will rename the corresponding parent slot.<br><br>Keyboard shortcut `0`
 
 ##Inputs
 ##Outputs

--- a/documentation/browser/plugins/slider_float_generator.md
+++ b/documentation/browser/plugins/slider_float_generator.md
@@ -1,8 +1,7 @@
 #Slider
 
 ##Description
-Emits a user controllable float value between two specified values.<br><br>
-Keyboard shortcut&nbsp;&nbsp;&nbsp;`3`
+Emits a user controllable float value between two specified values.<br><br>Keyboard shortcut&nbsp;&nbsp;&nbsp;`3`
 
 ##Inputs
 ##Outputs

--- a/documentation/browser/plugins/slider_float_generator.md
+++ b/documentation/browser/plugins/slider_float_generator.md
@@ -1,7 +1,8 @@
 #Slider
 
 ##Description
-Emits a user controllable float value between two specified values.
+Emits a user controllable float value between two specified values.<br><br>
+Keyboard shortcut `3`
 
 ##Inputs
 ##Outputs

--- a/documentation/browser/plugins/slider_float_generator.md
+++ b/documentation/browser/plugins/slider_float_generator.md
@@ -2,7 +2,7 @@
 
 ##Description
 Emits a user controllable float value between two specified values.<br><br>
-Keyboard shortcut `3`
+Keyboard shortcut&nbsp;&nbsp;&nbsp;`3`
 
 ##Inputs
 ##Outputs

--- a/documentation/browser/plugins/toggle_button.md
+++ b/documentation/browser/plugins/toggle_button.md
@@ -1,7 +1,7 @@
 #Boolean toggle
 
 ##Description
-Toggle button that emits true and false as it is clicked.
+Toggle button that emits true and false as it is clicked.<br><br>Keyboard shortcut `8`
 
 ##Inputs
 ##Outputs

--- a/documentation/browser/plugins/toggle_button.md
+++ b/documentation/browser/plugins/toggle_button.md
@@ -1,7 +1,7 @@
 #Boolean toggle
 
 ##Description
-Toggle button that emits true and false as it is clicked.<br><br>Keyboard shortcut `8`
+Toggle button that emits true and false as it is clicked.<br><br>Keyboard shortcut&nbsp;&nbsp;&nbsp;`8`
 
 ##Inputs
 ##Outputs

--- a/documentation/browser/plugins/vector.md
+++ b/documentation/browser/plugins/vector.md
@@ -1,7 +1,7 @@
 #XYZ to Vector
 
 ##Description
-Create a vector from individual X, Y and Z components.
+Create a vector from individual X, Y and Z components.<br><br>Keyboard shortcut `7`
 
 ##Inputs
 ###x

--- a/documentation/browser/plugins/vector.md
+++ b/documentation/browser/plugins/vector.md
@@ -1,7 +1,7 @@
 #XYZ to Vector
 
 ##Description
-Create a vector from individual X, Y and Z components.<br><br>Keyboard shortcut `7`
+Create a vector from individual X, Y and Z components.<br><br>Keyboard shortcut&nbsp;&nbsp;&nbsp;`7`
 
 ##Inputs
 ###x


### PR DESCRIPTION
Here's keyboard shortcut stuff added to each and every of the 10 shortcuts (Handy Keys, remember them?).

![keyboard-shortcut](https://user-images.githubusercontent.com/4966687/27792986-d58e981a-6004-11e7-88d1-a6f6db140c0e.gif)

modified:
Input: 1 (( input_proxy.md ))
Nested patch: 2 (( graph.md ))
Slider: 3 (( slider_float_generator.md ))
Number: 4 ((const_float_generator.md ))
Float: 5 (( float_display.md ))
Multiply Number 6 (( multiply_modulator.md )) 
XYZ to Vector: 7 (( vector.md ))
Toggle: 8 (( toggle_button.md ))
Knob: 9 (( knob_float_generator.md ))
Output: 0 (( output_proxy.md ))


next step: find someone to modify CSS so the keyboard shortcut text looks like what @mattatgit suggested: 

> Instead of white should be darker blue
> bit lighter than background
> number same colour as other text. 
> #3F4963 "this is for the keyboard shortcut key name box background"